### PR TITLE
feature: add unitlist generation command

### DIFF
--- a/gen3-cli/cot/backend/create/unitlist/__init__.py
+++ b/gen3-cli/cot/backend/create/unitlist/__init__.py
@@ -1,0 +1,22 @@
+from cot.backend.common import runner
+
+
+def run(
+    generation_input_source=None,
+    output_dir=None,
+    generation_provider=None,
+    generation_framework=None,
+    generation_testcase=None,
+    generation_scenarios=None,
+    _is_cli=False
+):
+    options = {
+        '-i': generation_input_source,
+        '-o': output_dir,
+        '-p': generation_provider,
+        '-f': generation_framework,
+        '-t': generation_testcase,
+        '-s': generation_scenarios,
+        '-l': 'unitlist'
+    }
+    runner.run('createTemplate.sh', [], options, _is_cli)

--- a/gen3-cli/cot/command/create/__init__.py
+++ b/gen3-cli/cot/command/create/__init__.py
@@ -4,6 +4,7 @@ from .template import template as template_cmd
 from .blueprint import blueprint as blueprint_cmd
 from .buildblueprint import buildblueprint as buildblueprint_cmd
 from .reference import reference as reference_cmd
+from .unitlist import unitlist as unitlist_cmd
 
 
 @cli.group('create')
@@ -17,3 +18,4 @@ group.add_command(template_cmd)
 group.add_command(blueprint_cmd)
 group.add_command(buildblueprint_cmd)
 group.add_command(reference_cmd)
+group.add_command(unitlist_cmd)

--- a/gen3-cli/cot/command/create/unitlist.py
+++ b/gen3-cli/cot/command/create/unitlist.py
@@ -1,0 +1,45 @@
+import click
+from cot.backend.create import unitlist as create_unitlist_backend
+
+
+@click.command(
+    'unitlist',
+    short_help='Create a unitlist output of the segment',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.option(
+    '-i',
+    '--generation-input-source',
+    help='source of input data to use when generating the template'
+)
+@click.option(
+    '-o',
+    '--output-dir',
+    help='the directory where the outputs will be saved. Mandatory when Input Source set to Mock.'
+)
+@click.option(
+    '-p',
+    '--generation-provider',
+    help='provider to for template generation',
+    default='aws',
+    show_default=True
+)
+@click.option(
+    '-f',
+    '--generation-framework',
+    help='output framework to use for template generation',
+    default='cf',
+    show_default=True
+)
+def unitlist(**kwargs):
+    """
+    Create a unit list output of the segment
+
+    \b
+    NOTES:
+
+    1. You must be in the directory specific to the level
+    """
+    create_unitlist_backend.run(**kwargs, _is_cli=True)

--- a/gen3-cli/tests/unit/command/create/test_unitlist.py
+++ b/gen3-cli/tests/unit/command/create/test_unitlist.py
@@ -1,0 +1,18 @@
+import collections
+from unittest import mock
+from click.testing import CliRunner
+from cot.command.create.unitlist import unitlist as create_unitlist
+from tests.unit.command.test_option_generation import run_options_test
+
+
+ALL_VALID_OPTIONS = collections.OrderedDict()
+
+ALL_VALID_OPTIONS['-p,--generation-provider'] = 'generation_provider'
+ALL_VALID_OPTIONS['-f,--generation-framework'] = 'generation_framework'
+ALL_VALID_OPTIONS['-i,--generation-input-source'] = 'input-source'
+ALL_VALID_OPTIONS['-o,--output-dir'] = '/tmp'
+
+
+@mock.patch('cot.command.create.unitlist.create_unitlist_backend')
+def test_input_valid(create_unitlist_backend):
+    run_options_test(CliRunner(), create_unitlist, ALL_VALID_OPTIONS, create_unitlist_backend.run)


### PR DESCRIPTION
## Description
supports the generation of the unitlist output which provides a list of deployment units for a given segment

## Motivation and Context
This aligns with the outputs available from createTemplate at the moment

## How Has This Been Tested?
Tested locally and tests included in PR

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
