### PR TITLE
fix: remove testcase and scenario inputs to align with bash

### DIFF
--- a/gen3-cli/cot/command/create/blueprint.py
+++ b/gen3-cli/cot/command/create/blueprint.py
@@ -22,7 +22,7 @@ from cot.backend.create import blueprint as create_blueprint_backend
 @click.option(
     '-p',
     '--generation-provider',
-    help='provider to for template generation',
+    help='provider to use for template generation',
     default='aws',
     show_default=True
 )
@@ -32,16 +32,6 @@ from cot.backend.create import blueprint as create_blueprint_backend
     help='output framework to use for template generation',
     default='cf',
     show_default=True
-)
-@click.option(
-    '-t',
-    '--generation-testcase',
-    help='test case you would like to generate a template for'
-)
-@click.option(
-    '-s',
-    '--generation-scenarios',
-    help='comma seperated list of framework scenarios to load'
 )
 def blueprint(**kwargs):
     """

--- a/gen3-cli/cot/command/create/buildblueprint.py
+++ b/gen3-cli/cot/command/create/buildblueprint.py
@@ -34,16 +34,6 @@ from cot.backend.create import buildblueprint as create_buildblueprint_backend
     show_default=True
 )
 @click.option(
-    '-t',
-    '--generation-testcase',
-    help='test case you would like to generate a template for'
-)
-@click.option(
-    '-s',
-    '--generation-scenarios',
-    help='comma seperated list of framework scenarios to load'
-)
-@click.option(
     '-u',
     '--deployment-unit',
     help='deployment unit to be included in the template',

--- a/gen3-cli/cot/command/create/template.py
+++ b/gen3-cli/cot/command/create/template.py
@@ -80,16 +80,6 @@ from cot.backend.create import template as create_template_backend
     show_default=True
 )
 @click.option(
-    '-t',
-    '--generation-testcase',
-    help='test case you would like to generate a template for'
-)
-@click.option(
-    '-s',
-    '--generation-scenarios',
-    help='comma seperated list of framework scenarios to load'
-)
-@click.option(
     '-i',
     '--generation-input-source',
     help='source of input data to use when generating the template'

--- a/gen3-cli/tests/unit/command/create/test_blueprint.py
+++ b/gen3-cli/tests/unit/command/create/test_blueprint.py
@@ -9,9 +9,7 @@ ALL_VALID_OPTIONS = collections.OrderedDict()
 
 ALL_VALID_OPTIONS['-p,--generation-provider'] = 'generation_provider'
 ALL_VALID_OPTIONS['-f,--generation-framework'] = 'generation_framework'
-ALL_VALID_OPTIONS['-t,--generation-testcase'] = 'generation_testcase'
 ALL_VALID_OPTIONS['-i,--generation-input-source'] = 'input-source'
-ALL_VALID_OPTIONS['-s,--generation-scenarios'] = 'generation_scenarious'
 ALL_VALID_OPTIONS['-o,--output-dir'] = '/tmp'
 
 

--- a/gen3-cli/tests/unit/command/create/test_buildblueprint.py
+++ b/gen3-cli/tests/unit/command/create/test_buildblueprint.py
@@ -10,9 +10,7 @@ ALL_VALID_OPTIONS = collections.OrderedDict()
 ALL_VALID_OPTIONS['!-u,--deployment-unit'] = 'deployment_unit'
 ALL_VALID_OPTIONS['-p,--generation-provider'] = 'generation_provider'
 ALL_VALID_OPTIONS['-f,--generation-framework'] = 'generation_framework'
-ALL_VALID_OPTIONS['-t,--generation-testcase'] = 'generation_testcase'
 ALL_VALID_OPTIONS['-i,--generation-input-source'] = 'input-source'
-ALL_VALID_OPTIONS['-s,--generation-scenarios'] = 'generation_scenarious'
 ALL_VALID_OPTIONS['-o,--output-dir'] = '/tmp'
 
 

--- a/gen3-cli/tests/unit/command/create/test_template.py
+++ b/gen3-cli/tests/unit/command/create/test_template.py
@@ -22,8 +22,6 @@ ALL_VALID_OPTIONS['-z,--deployment-unit-subset'] = 'deployment_unit_subset'
 ALL_VALID_OPTIONS['-d,--deployment-mode'] = 'deployment_mode'
 ALL_VALID_OPTIONS['-p,--generation-provider'] = 'generation_provider'
 ALL_VALID_OPTIONS['-f,--generation-framework'] = 'generation_framework'
-ALL_VALID_OPTIONS['-t,--generation-testcase'] = 'generation_testcase'
-ALL_VALID_OPTIONS['-s,--generation-scenarios'] = 'generation_scenarios'
 ALL_VALID_OPTIONS['-i,--generation-input-source'] = 'generation_input_source'
 ALL_VALID_OPTIONS['-o,--output-dir'] = 'output_dir'
 


### PR DESCRIPTION
## Description
Removes these inputs to align with their remove from the bash executor

## Motivation and Context
While scenarios and test cases still exist they have  been implemented inside of the engine rather than as external inputs. So their input parameters are no longer required

## How Has This Been Tested?
tested locally and in unit tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
