### PR TITLE
feature: trigger hamlet builds from updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+#!groovy
+
+pipeline {
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+        quietPeriod(30)
+    }
+
+    agent none
+
+    stages {
+        stage('Trigger Docker Build') {
+            when {
+                branch 'master'
+                beforeAgent true
+            }
+            agent none
+            steps {
+                build (
+                    job: '../docker-hamlet/master'
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds a build trigger to start the rebuild of the hamlet offical containers on updates to the master branch of this repo

## Motivation and Context
Ensures our container images have the lastet version of the cli installed

## How Has This Been Tested?
Will be tested on automation server using this PR

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
