### PR TITLE
feat: support additonal pytest arguments on run

### DIFF
--- a/hamlet-cli/hamlet/backend/test/run.py
+++ b/hamlet-cli/hamlet/backend/test/run.py
@@ -4,6 +4,7 @@ from pytest import ExitCode as ec
 
 def run(
     testpaths=None,
+    pytest_args=None,
     silent=True
 ):
     testpaths = testpaths or []
@@ -13,8 +14,15 @@ def run(
             'pytest',
             '-xvvs' if not silent else '-x',
             '--cache-clear',
+        ]
+
+        if pytest_args is not None:
+            args.append(pytest_args)
+
+        args += [
             *testpaths,
         ]
+
         cmd = " ".join(args)
         stdin = subprocess.PIPE
         stderr = subprocess.PIPE

--- a/hamlet-cli/hamlet/command/test/run.py
+++ b/hamlet-cli/hamlet/command/test/run.py
@@ -23,13 +23,19 @@ from hamlet.backend.test import run as test_run_backend
     )
 )
 @click.option(
+    '-p',
+    '--pytest-args',
+    'pytest_args',
+    help='additional arguments for pytest'
+)
+@click.option(
     '-s',
     '--silent',
     'silent',
     is_flag=True,
     help='minimize pytest output'
 )
-def run(tests, silent):
+def run(tests, pytest_args, silent):
     """
     Discover and run tests in specified files or/and directories. If no tests paths provided
     current directory used as tests discovery root.
@@ -38,5 +44,6 @@ def run(tests, silent):
         tests = (os.getcwd(),)
     test_run_backend.run(
         testpaths=tests,
-        silent=silent
+        pytest_args=pytest_args,
+        silent=silent,
     )

--- a/hamlet-cli/requirements/prod.txt
+++ b/hamlet-cli/requirements/prod.txt
@@ -5,11 +5,7 @@ Jinja2==2.11.2
 marshmallow==3.7.1
 jmespath==0.10.0
 
-# pytest >= 5.4.0 doesn't work with pytest-sugar <= 0.9.2
-# once https://github.com/Teemu/pytest-sugar/pull/188 is
-# merged, the upper bound can be removed.
-# Ref: https://github.com/pytest-dev/pytest/issues/6931
-pytest>=5.3.5,<5.4.0
+pytest>=5.3.5
 
 # AWS specifc tools
 cfn-flip==1.2.3

--- a/hamlet-cli/requirements/prod.txt
+++ b/hamlet-cli/requirements/prod.txt
@@ -5,7 +5,7 @@ Jinja2==2.11.2
 marshmallow==3.7.1
 jmespath==0.10.0
 
-pytest>=5.3.5
+pytest==6.0.2
 
 # AWS specifc tools
 cfn-flip==1.2.3

--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=packages,
     install_requires=[
         'click>=7.0.0,<8.0.0',
-        'pytest>=5.3.5,<5.4.0',
+        'pytest>=5.3.5,<7.0.0',
         'cookiecutter>=1.6.0,<2.0.0',
         'tabulate>=0.8.0,<1.0.0',
         'Jinja2>=2.10.0,<3.0.0',


### PR DESCRIPTION
## Description
Adds support for passing parameters directly to pytest when we run template testing

## Motivation and Context
The main motivation for this is to generate junit test results which can be used in our CI process to show more detailed testing reports during the testing process

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
