### PR TITLE
fix: allow for int outputs in tables

### DIFF
--- a/hamlet-cli/hamlet/command/common/display.py
+++ b/hamlet-cli/hamlet/command/common/display.py
@@ -9,6 +9,8 @@ MAX_TABLE_TEXT_CONTENT_WIDTH = 128
 def wrap_text(text):
     if text is None:
         return "None"
+    if text is isinstance(text, int):
+        return text
     return "\n".join(textwrap.wrap(text, MAX_TABLE_TEXT_CONTENT_WIDTH))
 
 

--- a/hamlet-cli/tests/unit/command/query/test.py
+++ b/hamlet-cli/tests/unit/command/query/test.py
@@ -521,7 +521,7 @@ def test_query_describe_occurence_get(blueprint_mock, ContextClassMock):
                                             {
                                                 'Attribute[3]': 'Value[3]',
                                                 'Attribute[4]': 'Value[4]',
-                                                'Attribute[5]': 'Value[5]'
+                                                'Attribute[5]': 5
                                             }
                                         ]
                                     },
@@ -573,7 +573,7 @@ def test_query_describe_occurence_attributes(blueprint_mock, ContextClassMock):
     } in result
     assert {
         'Key': 'Attribute[5]',
-        'Value': 'Value[5]'
+        'Value': 5
     } in result
 
 


### PR DESCRIPTION
## Description
Minor fix to support outputs from query commands which contain numbers

## Motivation and Context
Currently when querying the attributes of a component which provided number outputs ( like a port ) the disaply command would fail

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
