### PR TITLE
fix(deploy): hamlet deploy to order sequence based on priority

### DIFF
--- a/hamlet-cli/hamlet/command/deploy/__init__.py
+++ b/hamlet-cli/hamlet/command/deploy/__init__.py
@@ -58,6 +58,7 @@ def group(ctx, generation_provider, generation_framework, generation_input_sourc
 LIST_DEPLOYMENTS_QUERY = (
     'Stages[].Steps[]'
     '.{'
+    'Priority:Priority,'
     'DeploymentGroup:Parameters.DeploymentGroup,'
     'DeploymentUnit:Parameters.DeploymentUnit,'
     'DeploymentProvider:Parameters.DeploymentProvider'
@@ -192,7 +193,8 @@ def run_deployments(generation, deployment_mode, deployment_group, deployment_un
         return -1
 
     click.echo(click.style('Deployments Found:', bold=True))
-    for deployment in deployments:
+    prioritised_deployments = sorted(deployments, key=lambda deployment: deployment.Priority)
+    for deployment in prioritised_deployments:
         deployment_group = deployment['DeploymentGroup']
         deployment_unit = deployment['DeploymentUnit']
         click.echo(f'[*] {deployment_group}/{deployment_unit}')
@@ -205,7 +207,7 @@ def run_deployments(generation, deployment_mode, deployment_group, deployment_un
             deployment_unit = deployment['DeploymentUnit']
             return f"{deployment_group}/{deployment_unit}"
 
-    with click.progressbar(deployments, label='Running Deployments', item_show_func=show_deployment) as deployments_list:
+    with click.progressbar(prioritised_deployments, label='Running Deployments', item_show_func=show_deployment) as deployments_list:
         for deployment in deployments_list:
             generate_args = {
                 'generation_provider': generation.generation_provider,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* `deploy` command query updated to retrieve the priority for a deployment
* `deploy run-deployments` command updated to loop over a sorted list of deployments based on priority

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Whilst the progress-bar displays a sorted list in the correct order, deployments are occurring based on their name in the list, which is `<level>/<deployment-unit>` which results in `application > segment > solution`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
