### PR TITLE
fix: make provider input supoprt multiple

### DIFF
--- a/hamlet-cli/hamlet/command/deploy/__init__.py
+++ b/hamlet-cli/hamlet/command/deploy/__init__.py
@@ -54,6 +54,7 @@ pass_generation = click.make_pass_decorator(Generation, ensure=True)
     '-p',
     '--generation-provider',
     help='provider for output generation',
+    default=['aws'],
     multiple=True,
     show_default=True
 )

--- a/hamlet-cli/hamlet/command/query/__init__.py
+++ b/hamlet-cli/hamlet/command/query/__init__.py
@@ -93,8 +93,9 @@ def occurrences_table(data):
 @click.option(
     '-p',
     '--generation-provider',
-    help='provider to for template generation',
-    default='aws',
+    help='provider for output generation',
+    default=['aws'],
+    multiple=True,
     show_default=True
 )
 @click.option(


### PR DESCRIPTION
## Description
Minor change to fix the provider parameter across the different command groups to support multiple providers

## Motivation and Context
The provider parameter was inconsistent 

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
