### PR TITLE
feat: add diagrams depdencies for visual

### DIFF
--- a/hamlet-cli/requirements/prod.txt
+++ b/hamlet-cli/requirements/prod.txt
@@ -10,3 +10,6 @@ pytest==6.0.2
 # AWS specifc tools
 cfn-flip==1.2.3
 cfn-lint>=0.25.0,<1.0.0 # need version to keep up with AWS CloudFormation Schema
+
+# Diagram drawing
+diagrams

--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -40,6 +40,7 @@ setup(
         'Jinja2>=2.10.0,<3.0.0',
         'cfn-lint>=0.25.0,<1.0.0',
         'cfn-flip>=1.2.0,<2.0.0',
+        'diagrams>=0.18.0,<1.0.0'
     ],
     include_package_data=True,
     python_requires='>=3.6',


### PR DESCRIPTION
## Description
Adds package dependencies required to use the diagram drawing executor as part of the diagrams provider

## Motivation and Context
Allows for running digrams generation in the hamlet container

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
