### PR TITLE
feat: command exceptions and azure deploys

### DIFF
--- a/hamlet-cli/hamlet/backend/common/runner.py
+++ b/hamlet-cli/hamlet/backend/common/runner.py
@@ -52,6 +52,8 @@ def run(script_name, args, options, _is_cli):
         process.wait()
         if not _is_cli and process.returncode != 0:
             raise BackendException(process.stderr.read())
+        if _is_cli and process.returncode != 0:
+            raise BackendException(f'{script_name} failed to run')
     finally:
         try:
             process.kill()

--- a/hamlet-cli/hamlet/command/common/exceptions.py
+++ b/hamlet-cli/hamlet/command/common/exceptions.py
@@ -1,0 +1,7 @@
+from click import ClickException, style
+
+class CommandError(ClickException):
+    """An exception occurred during processing"""
+
+    def format_message(self):
+        return style(str(self.message), bold=True, fg='red')

--- a/hamlet-cli/hamlet/command/entrance/__init__.py
+++ b/hamlet-cli/hamlet/command/entrance/__init__.py
@@ -6,8 +6,10 @@ from tabulate import tabulate
 
 from hamlet.command import root as cli
 from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common.exceptions import CommandError
 from hamlet.backend.create import template as create_template_backend
 from hamlet.backend import query as query_backend
+from hamlet.backend.common.exceptions import BackendException
 
 
 class Generation(object):
@@ -187,4 +189,9 @@ def invoke_entrance(generation, **kwargs):
         "generation_input_source": generation.generation_input_source,
         **kwargs
     }
-    create_template_backend.run(**args, _is_cli=True)
+
+    try:
+        create_template_backend.run(**args, _is_cli=True)
+
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/credentials_crypto.py
+++ b/hamlet-cli/hamlet/command/manage/credentials_crypto.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.manage import credential_crypto as manage_credentials_crypto_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'credential-crypto',
@@ -73,4 +74,8 @@ def credentials_crypto(**kwargs):
     4. For CREDENTIAL_TYPE of ${CREDENTIAL_TYPE_API}, Id Attribute = AccessKey, Secret Attribute = SecretKey
     5. For CREDENTIAL_TYPE of ${CREDENTIAL_TYPE_ENV}, Id Attribute = ACCESS_KEY, Secret Attribute = SECRET_KEY
     """
-    manage_credentials_crypto_backend.run(**kwargs, _is_cli=True)
+    try:
+        manage_credentials_crypto_backend.run(**kwargs, _is_cli=True)
+
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/crypto.py
+++ b/hamlet-cli/hamlet/command/manage/crypto.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.manage import crypto as manage_crypto_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'crypto',
@@ -113,4 +114,8 @@ def crypto(**kwargs):
        visibility flag is set
     8. Decrypted files will have a ".decrypted" extension added so they can be ignored by git
     """
-    manage_crypto_backend.run(**kwargs, _is_cli=True)
+    try:
+        manage_crypto_backend.run(**kwargs, _is_cli=True)
+
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/deployment.py
+++ b/hamlet-cli/hamlet/command/manage/deployment.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.manage import deployment as manage_deployment_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'deployment',
@@ -80,4 +81,7 @@ def deployment(**kwargs):
     """
     Manage an Azure Resource Manager (ARM) deployment
     """
-    manage_deployment_backend.run(**kwargs, _is_cli=True)
+    try:
+        manage_deployment_backend.run(**kwargs, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/file_crypto.py
+++ b/hamlet-cli/hamlet/command/manage/file_crypto.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.manage import file_crypto as manage_file_crypto_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'file-crypto',
@@ -46,4 +47,7 @@ def file_crypto(**kwargs):
     NOTES:
     1. If no operation is provided, the current file contents are displayed
     """
-    manage_file_crypto_backend.run(**kwargs, _is_cli=True)
+    try:
+        manage_file_crypto_backend.run(**kwargs, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/stack.py
+++ b/hamlet-cli/hamlet/command/manage/stack.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.manage import stack as manage_stack_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'stack',
@@ -77,4 +78,8 @@ def stack(**kwargs):
     6. A dryrun creates a change set, then displays it. It only applies when
        the STACK_OPERATION=update
     """
-    manage_stack_backend.run(**kwargs, _is_cli=True)
+    try:
+        manage_stack_backend.run(**kwargs, _is_cli=True)
+
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/run/expo_app_publish.py
+++ b/hamlet-cli/hamlet/command/run/expo_app_publish.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.run import expo_app_publish as run_expo_app_publish_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'expo-app-publish',
@@ -69,4 +70,7 @@ def expo_app_publish(**kwargs):
     NOTES:
     RELEASE_CHANNEL default is environment
     """
-    run_expo_app_publish_backend.run(**kwargs, _is_cli=True)
+    try:
+        run_expo_app_publish_backend.run(**kwargs, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/run/lambda_func.py
+++ b/hamlet-cli/hamlet/command/run/lambda_func.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.run import lambda_func as run_lambda_func_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'lambda',
@@ -36,4 +37,7 @@ def lambda_func(**kwargs):
     """
     Run an AWS Lambda Function
     """
-    run_lambda_func_backend.run(**kwargs, _is_cli=True)
+    try:
+        run_lambda_func_backend.run(**kwargs, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/run/pipeline.py
+++ b/hamlet-cli/hamlet/command/run/pipeline.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.run import pipeline as run_pipeline_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'pipeline',
@@ -52,4 +53,7 @@ def pipeline(**kwargs):
     1. This will activate the pipeline and leave it running
     2. Pipelines take a long time so it is better to provide status via other means
     """
-    run_pipeline_backend.run(**kwargs, _is_cli=True)
+    try:
+        run_pipeline_backend.run(**kwargs, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/run/sentry_release.py
+++ b/hamlet-cli/hamlet/command/run/sentry_release.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.run import sentry_release as run_sentry_release_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'sentry-release',
@@ -36,4 +37,7 @@ def sentry_release(**kwargs):
     """
     Upload sourcemap files to sentry for a specific release
     """
-    run_sentry_release_backend.run(**kwargs, _is_cli=True)
+    try:
+        run_sentry_release_backend.run(**kwargs, _is_cli=True)
+    except BackendExceptions as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/run/task.py
+++ b/hamlet-cli/hamlet/command/run/task.py
@@ -1,6 +1,7 @@
 import click
 from hamlet.backend.run import task as run_task_backend
-
+from hamlet.backend.common.exceptions import BackendException
+from hamlet.command.common.exceptions import CommandError
 
 @click.command(
     'task',
@@ -80,4 +81,7 @@ def task(**kwargs):
     1. The ECS cluster is found using the provided tier and component combined with the product and segment
     2. ENV and VALUE should always appear in pairs
     """
-    run_task_backend.run(**kwargs, _is_cli=True)
+    try:
+        run_task_backend.run(**kwargs, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/visual/__init__.py
+++ b/hamlet-cli/hamlet/command/visual/__init__.py
@@ -6,8 +6,10 @@ from tabulate import tabulate
 
 from hamlet.command import root as cli
 from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common.exceptions import CommandError
 from hamlet.backend.create import template as create_template_backend
 from hamlet.backend import query as query_backend
+from hamlet.backend.common.exceptions import BackendException
 
 
 class Generation(object):
@@ -156,4 +158,7 @@ def draw_diagram(generation, **kwargs):
         "entrance": 'diagram',
         **kwargs
     }
-    create_template_backend.run(**args, _is_cli=True)
+    try:
+        create_template_backend.run(**args, _is_cli=True)
+    except BackendException as e:
+        raise CommandError(str(e))


### PR DESCRIPTION
## Description
- Adds cleaner handling of exceptions raised from calls to the backend which have failed when called from the command line. 

Instead of a full stack trace along with the script STDERR we now show the following 

<img width="642" alt="Screen Shot 2021-01-13 at 14 53 27" src="https://user-images.githubusercontent.com/16523764/104404621-3282c200-55af-11eb-920a-e3eb29388070.png">


The error text will also be bolded red

- Adds support for running Azure deployments using the hamlet run-deployments command and also adds an exception if a provider isn't supported

## Motivation and Context
While its bad that that the script fails the command itself hasn't really failed as an exception. So our handling of these exceptions should be to show the user what happened

Adding support for azure provides consistency with our offical providers and their use with the hamlet cli

## How Has This Been Tested?
Tested locally and through local test suite

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
