### PR TITLE
feat(generate)!: support provider types in account

### DIFF
--- a/hamlet-cli/hamlet/command/generate/cmdb.py
+++ b/hamlet-cli/hamlet/command/generate/cmdb.py
@@ -14,8 +14,8 @@ def group():  # pragma: no cover
 @dynamic_option('--account-id', required=True)
 @dynamic_option('--account-name', default=lambda p: p.account_id)
 @dynamic_option('--account-seed', default=lambda p: generate_account_backend.generate_account_seed())
-@dynamic_option('--account-type', default='aws')
-@dynamic_option('--aws-account-id', default=lambda p: '' if p.account_type == 'aws' else 'n/a')
+@dynamic_option('--provider-type', default='aws')
+@dynamic_option('--provider-id', required=True )
 @click.option('--prompt', is_flag=True)
 @click.option('--use-default', is_flag=True)
 @click.pass_context

--- a/hamlet-cli/tests/unit/command/generate/cmdb/test_account.py
+++ b/hamlet-cli/tests/unit/command/generate/cmdb/test_account.py
@@ -6,11 +6,10 @@ from tests.unit.command.generate.test_generate_command import run_generate_comma
 
 OPTIONS = collections.OrderedDict()
 OPTIONS['!--account-id,account_id'] = 'test-account-id'
+OPTIONS['!--provider-id,provider_id'] = 'test-provider-id'
 OPTIONS['--account-name,account_name'] = ('test-account-name', 'test-account-id')
 OPTIONS['--account-seed,account_seed'] = ('not-random-seed', 'random-seed')
-OPTIONS['--account-type,account_type'] = ('not-default-type', 'aws')
-OPTIONS['--aws-account-id,aws_account_id'] = ('not-default-aws-id', '')
-
+OPTIONS['--provider-type,provider_type'] = ( 'not-test-provider-type', 'test-provider-type' )
 
 @mock.patch('hamlet.command.generate.cmdb.generate_account_backend')
 def test(generate_account_backend):


### PR DESCRIPTION
## Description
Python executor implementation of https://github.com/hamlet-io/executor-cookiecutter/pull/10 


## Motivation and Context
Aligns with recent updates to the engine which move to a more generic configuration of accounts

## How Has This Been Tested?
Tested locally 

## Types of changes:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
Note this has changed some of the command options for the hamlet generate cmdb account command 
- account-type = provider-type 
- aws-account-id = provider-id


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
