### PR TITLE
feat: diagram generation from cli

### DIFF
--- a/hamlet-cli/hamlet/backend/draw/diagram.py
+++ b/hamlet-cli/hamlet/backend/draw/diagram.py
@@ -1,0 +1,61 @@
+import os
+import json
+from marshmallow import ValidationError
+from hamlet.backend.common.exceptions import UserFriendlyBackendException
+from .render import create_script
+from .diagram_schema import Diagram as DiagramSchema
+
+
+DIAGRAM_OUTPUT_PREFIX = 'diagram'
+DIAGRAM_CONFIG_OUTPUT_SUFFIX = '-config.json'
+DIAGRAM_SCRIPT_OUTPUT_SUFFIX = '-script.py'
+DIAGRAM_IMAGE_OUTPUT_SUFFIX = '-digaram.png'
+
+
+def run(
+    filename=None,
+    directory=None,
+    output_dir=None,
+    type=None
+):
+    filename = ''
+    diagram_prefix = f'{DIAGRAM_OUTPUT_PREFIX}-{type}-'
+
+    # searching testcase files in given directory if no files provided
+    if not filename and directory:
+        if not type:
+            raise UserFriendlyBackendException('Diagram type required if using directory search')
+
+        for name in os.listdir(directory):
+            if name.startswith(diagram_prefix) and name.endswith(DIAGRAM_CONFIG_OUTPUT_SUFFIX):
+                filename = os.path.join(directory, name)
+    # if after all no files found raise an error
+    if not filename:
+        raise UserFriendlyBackendException('No diagram file found')
+
+    diagram = dict()
+    with open(filename, 'rt') as f:
+        diagram_file_data = json.load(f)
+        try:
+            DiagramSchema().load(diagram_file_data)
+        except ValidationError as e:
+            message = json.dumps(e.messages, indent=4)
+            raise UserFriendlyBackendException(
+                f"Invalid diagram schema in {filename}\n\nErrors: \n{message}"
+            ) from e
+        diagram.update(**diagram_file_data)
+
+    # if files have no diagrams data
+    if not diagram:
+        raise UserFriendlyBackendException('No diagram found!')
+
+    # Create outputs
+    script_file_path = os.path.join(output_dir, filename.replace(DIAGRAM_CONFIG_OUTPUT_SUFFIX, DIAGRAM_SCRIPT_OUTPUT_SUFFIX))
+    image_file_path = os.path.join(output_dir, filename.replace(DIAGRAM_CONFIG_OUTPUT_SUFFIX, DIAGRAM_IMAGE_OUTPUT_SUFFIX))
+
+    text = create_script(diagram, image_file_path, script_file_path)
+    if text is not None:
+        with open(script_file_path, 'w+t') as f:
+            f.write(str(text))
+    exec(text)
+    return text

--- a/hamlet-cli/hamlet/backend/draw/diagram_schema.py
+++ b/hamlet-cli/hamlet/backend/draw/diagram_schema.py
@@ -1,0 +1,27 @@
+from marshmallow import Schema, fields
+
+
+class Entities(Schema):
+    entityID = fields.String(required=True)
+    groupID = fields.String(required=True)
+    type = fields.String(required=True)
+    entityName = fields.String(required=True)
+
+
+class Relationships(Schema):
+    startEntityID = fields.String(required=True)
+    endEntityID = fields.String(required=True)
+    direction = fields.String(required=True)
+
+
+class Groups(Schema):
+    groupID = fields.String(required=True)
+    parentID = fields.String(required=True)
+
+
+class Diagram(Schema):
+    Metadata = fields.Raw()
+    diagramName = fields.String(required=True)
+    entities = fields.Nested(Entities(many=True))
+    relationships = fields.Nested(Relationships(many=True))
+    groups = fields.Nested(Groups(many=True))

--- a/hamlet-cli/hamlet/backend/draw/render.py
+++ b/hamlet-cli/hamlet/backend/draw/render.py
@@ -1,0 +1,221 @@
+import os
+from jinja2 import Template
+
+
+class Group(object):
+    '''
+    A cluster of entities
+    '''
+    def __init__(self, dit):
+        self.parentID = dit['parentID']
+        self.groupID = dit['groupID']
+        self.childIDs = []
+        self.entities = []
+        self.template = ''
+        self.entityStr = ''
+        self.rank = 0  # the rank of groups increment as it goes deeper
+        self.libraries = []
+
+    def findChildGroups(self, groups):
+        '''
+        find child groups for parent groups, store childIDs for group object
+        '''
+        for group in groups:
+            if group.parentID == self.groupID and group != self:
+                self.childIDs.append(group)
+
+    def findEntities(self, entitiesGroup):
+        '''
+        find entities of each group, store entities for group object
+        '''
+        for en in entitiesGroup:
+            if en['groupID'] == self.groupID:
+                self.libraries.append(en['type'])  # save for library import
+                en['type'] = en['type'].split('.')[-1]  # retrieve the last word as type
+                self.entities.append(en)
+
+    def createCluster(self):
+        '''
+        create Cluster template
+        '''
+        template = Template("""\
+                with Cluster("{{groupID}}"):
+                    {% for entity in entities %}
+                    {{entity.entityID}}={{entity.type}}("{{entity.entityName}}")
+                    {% endfor %}
+            """).render(groupID=self.groupID, entities=self.entities)
+        self.entityStr = template
+        self.template = template
+        return self.template
+
+
+def create_script(diagram, image_filename, temp_path):
+    '''
+    Generates a diagrams formatted python script
+    '''
+
+    diagramName = diagram['diagramName']
+    groups = diagram['groups']
+    entities = diagram['entities']
+    relationships = diagram['relationships']
+
+    image_filename = os.path.splitext(image_filename)[0]
+
+    # build all group objects and store in list
+    # create list of group objects, array in json is list in python
+    groupObjects = []  # it has the length of group list
+    for group in groups:
+        groupObjects.append(Group(group))
+
+    # find entities for each group and store
+    for groupObj in groupObjects:
+        groupObj.findEntities(entities)
+
+    # match rank for each group and store
+    rank_list = []
+
+    def matchRank(groupObjects):
+        allobjects = groupObjects.copy()
+        if rank_list == []:
+            for obj in groupObjects:
+                # identify and remove groups with no parent
+                if obj.parentID == '':
+                    obj.rank = 1
+                    rank_list.append(obj)
+                    allobjects.remove(obj)
+            groupObjects = allobjects
+            matchRank(groupObjects)
+        else:
+            if allobjects != []:  # there are still objs unmatched
+                for pa_obj in rank_list:
+                    for obj in groupObjects:
+                        if pa_obj.groupID == obj.parentID:
+                            obj.rank = pa_obj.rank + 1
+                            rank_list.append(obj)
+                            allobjects.remove(obj)
+                groupObjects = allobjects
+                matchRank(groupObjects)
+            else:
+                return rank_list
+    matchRank(groupObjects)
+
+    # find child groups for each group and create template
+    childGroups = []
+    for groupObj in groupObjects:
+        groupObj.findChildGroups(groupObjects)  # childIDs list is populated
+        groupObj.createCluster()
+        if groupObj.childIDs == []:  # if this group object has no child groups, save it as its own child group???
+            childGroups.append(groupObj)
+
+    def removeDuplicates(list):
+        new_list = []
+        for li in list:
+            if li not in new_list:
+                new_list.append(li)
+        return new_list
+
+    def findParents(childGroups, allObjects, rootGroups):
+        '''
+        find parent group for each child group and combine Clusters
+        '''
+        parentIDs = []
+        for child in childGroups:
+            if child.parentID == '':
+                rootGroups.append(child)
+            else:
+                parentIDs.append(child.parentID)
+        if parentIDs == []:
+            return 'all groups are root groups', removeDuplicates(rootGroups)
+        parentIDs = removeDuplicates(parentIDs)
+
+        parentsList = []
+        for parent in parentIDs:
+            template = Template("""\n
+            with Cluster("{{parentID}}"):
+                {% for child in childGroups %}
+                {% if child.parentID == parentID %}
+                {{child.template}}
+                {% endif %}
+                {% endfor %}
+            """).render(parentID=parent, childGroups=childGroups)
+            for obj in allObjects:
+                if obj.groupID == parent:
+                    obj.template = obj.template + template
+                    parentsList.append(obj)
+
+        return findParents(parentsList, allObjects, rootGroups), removeDuplicates(rootGroups)
+
+    # write all parent groups into template file
+    with open(temp_path, 'w+', encoding='utf-8') as f:
+        for g in findParents(childGroups, groupObjects, [])[1]:
+            f.write(g.template)
+
+    # retrive parent groups file and remove redundant spaces. (Jinja2 template generates lots of spaces and empty lines)
+    with open(temp_path, 'r', encoding='utf-8') as f:
+        lines = []
+        for line in f.readlines():
+            if line.strip() != '':
+                lines.append(line)
+
+    # insert remaining entities if there are any
+    for obj in groupObjects:
+        if obj.entities != [] and obj.childIDs != []:
+            str = "with Cluster(\"{}\"):".format(obj.groupID)
+            lines = [obj.entityStr if l == str else l for l in lines]
+
+    # write template in file
+    with open(temp_path, 'w+', encoding='utf-8') as f:
+        for l in lines:
+            f.write(l + '\n')
+
+    # remove redundant spaces and empty lines
+    with open(temp_path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+        lines = [l.strip() for l in lines]
+        lines = [l for l in lines if l != '']
+        lines = removeDuplicates(lines)
+
+        # get group rank for Cluster
+        def clusterRank(str):
+            name = str.split('"')[1].split('"')[0]
+            for obj in groupObjects:
+                if obj.groupID == name:
+                    return obj.rank
+
+        # import libraries from entity types
+        import_diagrams = (
+            "import diagrams\nfrom diagrams import Cluster, Diagram, Edge\nfrom diagrams.generic.blank import Blank\n"
+        )
+        imported_libraries = []
+        for obj in groupObjects:
+            for diagClass in obj.libraries:
+                library = diagClass.rsplit('.', 1)[0]
+                if library not in imported_libraries:
+                    imported_libraries.append(library)
+                    import_libray = 'from {} import *\n'.format(library)
+                    import_diagrams = import_diagrams + import_libray
+
+        exe_temp = import_diagrams + f'\nwith Diagram("{diagramName}", show=False, outformat="png", filename="{image_filename}", direction="TB"):\n'
+        space = '    '  # indent
+        rank = 0
+        for i in range(len(lines)):
+            if 'with' in lines[i]:
+                rank = clusterRank(lines[i])
+                lines[i] = space * rank + lines[i] + '\n'  # indent according to ranks
+            else:
+                if 'with' in lines[i - 1]:
+                    rank = rank + 1
+                lines[i] = space * rank + lines[i] + '\n'
+            exe_temp = exe_temp + lines[i]
+
+    # add relationships
+    for rela in relationships:
+        if isinstance(rela, dict):
+            if rela['direction'] == 'one way':
+                rela_str = f'{space}{rela["startEntityID"]} >> Edge() >> {rela["endEntityID"]}\n'
+                exe_temp = exe_temp + rela_str
+            elif rela['direction'] == 'two way':
+                rela_str = f'{space}{rela["startEntityID"]} >> Edge() << {rela["endEntityID"]}\n'
+                exe_temp = exe_temp + rela_str
+
+    return exe_temp

--- a/hamlet-cli/tests/unit/command/visual/test_draw.py
+++ b/hamlet-cli/tests/unit/command/visual/test_draw.py
@@ -7,25 +7,28 @@ from tests.unit.command.test_option_generation import run_options_test, run_vali
 
 ALL_VALID_OPTIONS = collections.OrderedDict()
 
-ALL_VALID_OPTIONS['!-l,--deployment-group'] = 'deployment_group'
+ALL_VALID_OPTIONS['!-t,--type'] = 'type'
+ALL_VALID_OPTIONS['!-o,--output-dir'] = './'
 ALL_VALID_OPTIONS['-x,--disable-output-cleanup'] = [True]
-ALL_VALID_OPTIONS['-o,--output-dir'] = 'output_dir'
 
 
+@mock.patch('hamlet.command.visual.create_diagram_backend')
 @mock.patch('hamlet.command.visual.create_template_backend')
-def test_input_valid(create_template_backend):
+def test_input_valid(create_template_backend, create_diagram_backend):
     run_options_test(CliRunner(), draw_diagram, ALL_VALID_OPTIONS, create_template_backend.run)
 
 
+@mock.patch('hamlet.command.visual.create_diagram_backend')
 @mock.patch('hamlet.command.visual.create_template_backend')
-def test_input_validation(create_template_backend):
+def test_input_validation(create_template_backend, create_diagram_backend):
     runner = CliRunner()
     run_validatable_option_test(
         runner,
         draw_diagram,
         create_template_backend.run,
         {
-            '-l': 'overview'
+            '-t': 'overview',
+            '-o': './'
         },
         []
     )

--- a/hamlet-cli/tests/unit/command/visual/test_list.py
+++ b/hamlet-cli/tests/unit/command/visual/test_list.py
@@ -49,13 +49,11 @@ def mock_backend(info=None):
             {
                 'Name': 'DiagramName[1]',
                 'Type': 'DiagramType[1]',
-                'DeploymentGroup': 'DiagramDeploymentGroup[1]',
                 'Description': 'DiagramDescription[1]',
             },
             {
                 'Name': 'DiagramName[2]',
                 'Type': 'DiagramType[2]',
-                'DeploymentGroup': 'DiagramDeploymentGroup[2]',
                 'Description': 'DiagramDescription[2]',
             },
         ]
@@ -76,12 +74,10 @@ def test_query_list_entrances(blueprint_mock, ContextClassMock):
     assert {
         'Name': 'DiagramName[1]',
         'Type': 'DiagramType[1]',
-        'DeploymentGroup': 'DiagramDeploymentGroup[1]',
         'Description': 'DiagramDescription[1]'
     } in result
     assert {
         'Name': 'DiagramName[2]',
         'Type': 'DiagramType[2]',
-        'DeploymentGroup': 'DiagramDeploymentGroup[2]',
         'Description': 'DiagramDescription[2]'
     } in result


### PR DESCRIPTION
## Description
Adds support for diagram generation as part of cli. This essentially merges the diagram generation script from https://github.com/hamlet-io/executor-diagrams and makes it available as a cli backend. The command will create the appropriate hamlet outputs, generate the diagram script and then execute the script to create the diagram. 

The output dir must be set at the moment as the cli doesn't know the CMDB output dirs during its processing 

Example

```bash
hamlet visual -i mock -p aws -p diagrams -p awsdiagrams draw-diagram --type overview -o ~/cmdb/testing/diagram_test/
```

Creates the following files 
```
/home/hamlet/cmdb/testing/diagram_test/
├── diagram-overview-config.json
├── diagram-overview-digaram.png
├── diagram-overview-generation-contract.json
└── diagram-overview-script.py
```

And the PNG contains the following 
![diagram-overview-gsha01-digaram](https://user-images.githubusercontent.com/16523764/106681666-0d64fa80-6615-11eb-89f5-bd0ecc6f2ba9.png)


## Motivation and Context
The main motivation for this is to make diagrams super easy to generate and extend the features of the hamlet cli 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
