### PR TITLE
fix: add output_dir to manage deployment

### DIFF
--- a/hamlet-cli/hamlet/backend/manage/deployment/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/deployment/__init__.py
@@ -12,6 +12,7 @@ def run(
     deployment_unit=None,
     deployment_wait=None,
     deployment_unit_subset=None,
+    output_dir=None,
     _is_cli=False
 ):
     options = {
@@ -24,6 +25,7 @@ def run(
         '-s': deployment_scope,
         '-u': deployment_unit,
         '-w': deployment_wait,
-        '-z': deployment_unit_subset
+        '-z': deployment_unit_subset,
+        '-o': output_dir
     }
     runner.run('manageDeployment.sh', [], options, _is_cli)


### PR DESCRIPTION
## Description
This allows for the run-deployments command to be executed from outputs not part of a CMDB

## Motivation and Context
Fixes an issue where run-deployments was expecting the manage deployment script to provide output_dir

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
