### PR TITLE
feat: multiple diagram generation

### DIFF
--- a/hamlet-cli/hamlet/backend/draw/render.py
+++ b/hamlet-cli/hamlet/backend/draw/render.py
@@ -195,7 +195,11 @@ def create_script(diagram, image_filename, temp_path):
                     import_libray = 'from {} import *\n'.format(library)
                     import_diagrams = import_diagrams + import_libray
 
-        exe_temp = import_diagrams + f'\nwith Diagram("{diagramName}", show=False, outformat="png", filename="{image_filename}", direction="TB"):\n'
+        exe_temp = (
+            import_diagrams
+            + f'\nwith Diagram("{diagramName}", show=False, outformat="png",'
+            + f'filename="{image_filename}", direction="TB"):\n'
+        )
         space = '    '  # indent
         rank = 0
         for i in range(len(lines)):

--- a/hamlet-cli/tests/unit/command/visual/test_draw.py
+++ b/hamlet-cli/tests/unit/command/visual/test_draw.py
@@ -1,34 +1,84 @@
 import collections
+import tempfile
+import hashlib
+import json
+import os
+
 from unittest import mock
 from click.testing import CliRunner
-from hamlet.command.visual import draw_diagram as draw_diagram
+from hamlet.command.visual import draw_diagrams as draw_diagrams
 from tests.unit.command.test_option_generation import run_options_test, run_validatable_option_test
 
 
 ALL_VALID_OPTIONS = collections.OrderedDict()
 
-ALL_VALID_OPTIONS['!-t,--type'] = 'type'
-ALL_VALID_OPTIONS['!-o,--output-dir'] = './'
-ALL_VALID_OPTIONS['-x,--disable-output-cleanup'] = [True]
+ALL_VALID_OPTIONS['!-i,--diagram-id'] = ['Diagram1']
+ALL_VALID_OPTIONS['!-d,--asset-dir'] = './'
+ALL_VALID_OPTIONS['-s,--src-dir'] = './'
 
 
-@mock.patch('hamlet.command.visual.create_diagram_backend')
-@mock.patch('hamlet.command.visual.create_template_backend')
+def template_backend_run_mock(data):
+    def run(
+        entrance='diagraminfo',
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        output_filename='diagraminfo.json'
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        unitlist_filename = os.path.join(output_dir, output_filename)
+        with open(unitlist_filename, 'wt+') as f:
+            json.dump(data, f)
+    return run
+
+
+def mock_backend(unitlist=None):
+    def decorator(func):
+        @mock.patch('hamlet.command.visual.create_diagram_backend')
+        @mock.patch('hamlet.command.visual.create_template_backend')
+        @mock.patch('hamlet.backend.query.context.Context')
+        @mock.patch('hamlet.backend.query.template')
+        def wrapper(blueprint_mock, ContextClassMock, create_template_backend, create_diagram_backend, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(hashlib.md5(str(unitlist).encode()).hexdigest())
+                ContextObjectMock.cache_dir = temp_cache_dir
+
+                blueprint_mock.run.side_effect = template_backend_run_mock(unitlist)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+diagram_list = {
+    'Diagrams': [
+        {
+            'Id': 'Diagram1',
+        }
+    ]
+}
+
+
+@mock_backend(diagram_list)
 def test_input_valid(create_template_backend, create_diagram_backend):
-    run_options_test(CliRunner(), draw_diagram, ALL_VALID_OPTIONS, create_template_backend.run)
+    run_options_test(CliRunner(), draw_diagrams, ALL_VALID_OPTIONS, create_template_backend.run)
 
 
-@mock.patch('hamlet.command.visual.create_diagram_backend')
-@mock.patch('hamlet.command.visual.create_template_backend')
+@mock_backend(diagram_list)
 def test_input_validation(create_template_backend, create_diagram_backend):
     runner = CliRunner()
     run_validatable_option_test(
         runner,
-        draw_diagram,
+        draw_diagrams,
         create_template_backend.run,
         {
-            '-t': 'overview',
-            '-o': './'
+            '-i': 'overview',
+            '-d': './'
         },
         []
     )

--- a/hamlet-cli/tests/unit/command/visual/test_list.py
+++ b/hamlet-cli/tests/unit/command/visual/test_list.py
@@ -2,9 +2,12 @@ import os
 import hashlib
 import json
 import tempfile
+
 from unittest import mock
+
 from click.testing import CliRunner
 from hamlet.command.visual import list_diagrams as list_diagrams
+from hamlet.command.visual import list_diagram_types as list_diagram_types
 
 
 def template_backend_run_mock(data):
@@ -47,19 +50,19 @@ def mock_backend(info=None):
     {
         'Diagrams': [
             {
-                'Name': 'DiagramName[1]',
+                'Id': 'DiagramId[1]',
                 'Type': 'DiagramType[1]',
                 'Description': 'DiagramDescription[1]',
             },
             {
-                'Name': 'DiagramName[2]',
+                'Id': 'DiagramId[2]',
                 'Type': 'DiagramType[2]',
                 'Description': 'DiagramDescription[2]',
             },
         ]
     }
 )
-def test_query_list_entrances(blueprint_mock, ContextClassMock):
+def test_query_list_diagrams(blueprint_mock, ContextClassMock):
     cli = CliRunner()
     result = cli.invoke(
         list_diagrams,
@@ -72,12 +75,48 @@ def test_query_list_entrances(blueprint_mock, ContextClassMock):
     result = json.loads(result.output)
     assert len(result) == 2
     assert {
-        'Name': 'DiagramName[1]',
+        'Id': 'DiagramId[1]',
         'Type': 'DiagramType[1]',
         'Description': 'DiagramDescription[1]'
     } in result
     assert {
-        'Name': 'DiagramName[2]',
+        'Id': 'DiagramId[2]',
+        'Type': 'DiagramType[2]',
+        'Description': 'DiagramDescription[2]'
+    } in result
+
+
+@mock_backend(
+    {
+        'DiagramTypes': [
+            {
+                'Type': 'DiagramType[1]',
+                'Description': 'DiagramDescription[1]',
+            },
+            {
+                'Type': 'DiagramType[2]',
+                'Description': 'DiagramDescription[2]',
+            },
+        ]
+    }
+)
+def test_query_list_diagram_types(blueprint_mock, ContextClassMock):
+    cli = CliRunner()
+    result = cli.invoke(
+        list_diagram_types,
+        [
+            '--output-format', 'json'
+        ]
+    )
+    print(result.exception)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 2
+    assert {
+        'Type': 'DiagramType[1]',
+        'Description': 'DiagramDescription[1]'
+    } in result
+    assert {
         'Type': 'DiagramType[2]',
         'Description': 'DiagramDescription[2]'
     } in result


### PR DESCRIPTION
## Description

- Adds support for generating multiple diagrams from a single command and aligns with the user generated diagram approach. This uses the same approach as the deployments commands which query the available commands and apply regex filtering based on the provided id

- Adds a list diagrams command to show the available commands

- Splits the output directories for source code and the generated diagram images. This allows for users to decide on what they require and where they can store each output type

## Motivation and Context

Makes the diagram generation process easier when a number of diagrams have been defined and also allows for automated processes to easily update the solution diagrams as required

## How Has This Been Tested?
Tested locally and with test suite

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
- The existing draw-diagram command has been replaced with draw-diagrams and the syntax has been updated significantly 
- Requires: https://github.com/hamlet-io/engine-plugin-diagrams/pull/13 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
