### PR TITLE
feat: generate command quality of life

### DIFF
--- a/hamlet-cli/hamlet/backend/common/context.py
+++ b/hamlet-cli/hamlet/backend/common/context.py
@@ -240,6 +240,7 @@ class RootLevel(Context):
     level_file = 'root.json'
     level_file_directory = None
 
+
 class TenantLevel(Context):
     level_name = 'tenant'
     level_file = 'tenant.json'

--- a/hamlet-cli/hamlet/backend/generate/utils.py
+++ b/hamlet-cli/hamlet/backend/generate/utils.py
@@ -11,7 +11,7 @@ def replace_parameters_values(kwargs, replacers=None):
                 break
 
 
-def cookiecutter(*template_path, **kwargs):
+def cookiecutter(*template_path, output_dir, **kwargs):
     replace_parameters_values(
         kwargs,
         [
@@ -24,5 +24,6 @@ def cookiecutter(*template_path, **kwargs):
     cookiecutter_main(
         template_path,
         no_input=True,
+        output_dir=output_dir,
         extra_context=kwargs
     )

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -15,6 +15,5 @@ def root(ctx, opts):
 
     # set global environment variables for template generation
     options = ctx.find_object(Options)
-    options_env = options.to_env_dict()
     for k, v in options.to_env_dict().items():
         os.environ[k] = v

--- a/hamlet-cli/hamlet/command/common/config.py
+++ b/hamlet-cli/hamlet/command/common/config.py
@@ -1,5 +1,8 @@
-from click_configfile import ConfigFileReader, Param, SectionSchema, matches_section
 import click
+import os
+
+from click_configfile import ConfigFileReader, Param, SectionSchema, matches_section
+
 
 class ConfigParam(Param):
     # For compatibility with click>=7.0
@@ -42,10 +45,10 @@ class ConfigSchema(object):
         environment = ConfigParam(name='environment', type=str)
         segment = ConfigParam(name='segment', type=str)
 
-
     @matches_section("profile:*")
     class Profile(Default):
         """Profile-specific configuration schema."""
+
 
 def get_default_config_path():
     """Get the default path to config files."""
@@ -204,8 +207,8 @@ class Options(object):
         self._set_option("segment", value)
 
     def to_env_dict(self):
-        env={}
-        for k,v in self.opts.items():
+        env = {}
+        for k, v in self.opts.items():
             if v is not None:
                 env[k.upper()] = v
         return env

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -1,8 +1,8 @@
 import click
 import functools
 
-from hamlet.command.common import config as config
 from hamlet.command.common.config import Options
+
 
 def common_cli_config_options(f):
     """Add common CLI config options to commands."""

--- a/hamlet-cli/hamlet/command/common/display.py
+++ b/hamlet-cli/hamlet/command/common/display.py
@@ -3,6 +3,7 @@ import functools
 import json
 import textwrap
 
+
 MAX_TABLE_TEXT_CONTENT_WIDTH = 128
 
 

--- a/hamlet-cli/hamlet/command/generate/__init__.py
+++ b/hamlet-cli/hamlet/command/generate/__init__.py
@@ -6,7 +6,7 @@ from .product import group as product_generation_group
 @cli.group('generate')
 def group():
     """
-    Generate various cmdb components
+    Generates base CMDB file system structures
     """
     pass
 

--- a/hamlet-cli/hamlet/command/generate/cmdb.py
+++ b/hamlet-cli/hamlet/command/generate/cmdb.py
@@ -1,8 +1,13 @@
 import click
+
+from cookiecutter.exceptions import OutputDirExistsException
+
 from hamlet.backend.generate.cmdb import account as generate_account_backend
 from hamlet.backend.generate.cmdb import tenant as generate_tenant_backend
 from hamlet.utils import dynamic_option, DynamicCommand
 from hamlet.command.generate import utils
+from hamlet.command.generate import decorators
+from hamlet.command.common.exceptions import CommandError
 
 
 @click.group('cmdb')
@@ -11,13 +16,38 @@ def group():  # pragma: no cover
 
 
 @group.command('account', cls=DynamicCommand)
-@dynamic_option('--account-id', required=True)
-@dynamic_option('--account-name', default=lambda p: p.account_id)
-@dynamic_option('--account-seed', default=lambda p: generate_account_backend.generate_account_seed())
-@dynamic_option('--provider-type', default='aws')
-@dynamic_option('--provider-id', required=True)
-@click.option('--prompt', is_flag=True)
-@click.option('--use-default', is_flag=True)
+@dynamic_option(
+    '--account-id',
+    help='The unique id for the account',
+    required=True,
+)
+@dynamic_option(
+    '--account-name',
+    help='A more descriptive name for the account',
+    default=lambda p: p.account_id,
+)
+@dynamic_option(
+    '--account-seed',
+    help='A random seed to ensure unique deployments',
+    default=lambda p: generate_account_backend.generate_account_seed(),
+)
+@dynamic_option(
+    '--provider-type',
+    help='The cloud provider the account represents',
+    type=click.Choice(
+        [
+            'aws',
+            'azure',
+        ]
+    ),
+    default='aws'
+)
+@dynamic_option(
+    '--provider-id',
+    help='The cloud provider Id for for the account (AWS Account Id or Azure Subscription)',
+    required=True
+)
+@decorators.common_generate_options
 @click.pass_context
 def generate_account(
     ctx,
@@ -32,18 +62,42 @@ def generate_account(
     This template should be run from a tenant directory
     """
     if not prompt or utils.confirm(kwargs):
-        generate_account_backend.run(**kwargs)
+        try:
+            generate_account_backend.run(**kwargs)
+
+        except OutputDirExistsException as e:
+            raise CommandError(e)
 
 
 @group.command('tenant', cls=DynamicCommand)
-@dynamic_option('--tenant-id', required=True)
-@dynamic_option('--tenant-name', default=lambda p: p.tenant_id)
-@dynamic_option('--domain-stem', default='')
-@dynamic_option('--default-region', default='ap-southeast-2')
-@dynamic_option('--audit-log-expiry-days', type=click.INT, default=2555)
-@dynamic_option('--audit-log-offline-days', type=click.INT, default=90)
-@click.option('--prompt', is_flag=True)
-@click.option('--use-default', is_flag=True)
+@dynamic_option(
+    '--tenant-id',
+    help='The unique Id for the tenant',
+    required=True,
+)
+@dynamic_option(
+    '--tenant-name',
+    help='A more descriptive name for the tenant',
+    default=lambda p: p.tenant_id,
+)
+@dynamic_option(
+    '--default-region',
+    help='The id of the default region to use for deployments in this tenant',
+    default='ap-southeast-2',
+)
+@dynamic_option(
+    '--audit-log-expiry-days',
+    help='How long to keep account audit logs for',
+    type=click.INT,
+    default=2555
+)
+@dynamic_option(
+    '--audit-log-offline-days',
+    help='How log until audit logs are sent to archive storage',
+    type=click.INT,
+    default=90
+)
+@decorators.common_generate_options
 @click.pass_context
 def generate_tenant(
     ctx,
@@ -56,4 +110,8 @@ def generate_tenant(
     This should be run from the root of an accounts repository.
     """
     if not prompt or utils.confirm(kwargs):
-        generate_tenant_backend.run(**kwargs)
+        try:
+            generate_tenant_backend.run(**kwargs)
+
+        except OutputDirExistsException as e:
+            raise CommandError(e)

--- a/hamlet-cli/hamlet/command/generate/decorators.py
+++ b/hamlet-cli/hamlet/command/generate/decorators.py
@@ -1,0 +1,35 @@
+import click
+import functools
+import os
+
+
+def common_generate_options(f):
+    """Add common options for the generate command group"""
+
+    @functools.wraps(f)
+    @click.option(
+        '--use-default',
+        help='If a default value is set, skip prompt for the value',
+        is_flag=True,
+    )
+    @click.option(
+        '--no-prompt',
+        help='Disable prompting for missing inputs and error on missing values',
+        is_flag=True
+    )
+    @click.option(
+        '--output-dir',
+        '-o',
+        help='The directory to save the generated content',
+        show_default=True,
+        type=click.Path(
+            file_okay=False,
+            dir_okay=True,
+            writable=True
+        ),
+        default=os.getcwd()
+    )
+    def wrapper(*args, **kwargs):
+        f(*args, **kwargs)
+
+    return wrapper

--- a/hamlet-cli/hamlet/utils/__init__.py
+++ b/hamlet-cli/hamlet/utils/__init__.py
@@ -42,12 +42,12 @@ class DynamicOption(click.Option):
     @property
     def prompt(self):
         try:
-            if self.ctx.params.get('prompt'):
+            if not self.ctx.params.get('no_prompt'):
                 if self.ctx.params.get('use_default') and self.default is not None:
                     return None
                 if callable(self.__prompt) and not self.__prompt(self.ContextValuesGetter(self.ctx)):
                     return None
-                return 'Enter %s' % self.human_readable_name.replace('_', ' ')
+                return '[?] %s' % self.human_readable_name.replace('_', ' ')
             else:
                 return None
         except (AttributeError, KeyError):

--- a/hamlet-cli/tests/integration/backend/create/template/test_context_tree.py
+++ b/hamlet-cli/tests/integration/backend/create/template/test_context_tree.py
@@ -21,11 +21,11 @@ def test_find_gen3_dirs(clear_cmdb, cmdb):
 
     with cmdb() as path:
         os.mknod('root.json')
-        tenant.run(**conf['cmdb']['tenant'])
-    with cmdb('accounts'):
-        account.run(**conf['cmdb']['account'])
-    with cmdb():
-        base.run(**conf['cmdb']['product'])
+        tenant.run(**conf['cmdb']['tenant'], output_dir=path())
+    with cmdb('accounts') as path:
+        account.run(**conf['cmdb']['account'], output_dir=path())
+    with cmdb() as path:
+        base.run(**conf['cmdb']['product'], output_dir=path())
     with cmdb('accounts', tenant_name):
         with open('domains.json', 'rb') as domains_file:
             domains_json = json.load(domains_file)

--- a/hamlet-cli/tests/integration/backend/create/template/test_set_context.py
+++ b/hamlet-cli/tests/integration/backend/create/template/test_set_context.py
@@ -17,13 +17,13 @@ def test(cmdb, clear_cmdb):
     product_id = conf['cmdb']['product']['product_id']
     product_name = conf['cmdb']['product']['product_name']
 
-    with cmdb():
+    with cmdb() as path:
         os.mknod('root.json')
-        tenant.run(**conf['cmdb']['tenant'])
-    with cmdb('accounts'):
-        account.run(**conf['cmdb']['account'])
-    with cmdb():
-        base.run(**conf['cmdb']['product'])
+        tenant.run(**conf['cmdb']['tenant'], output_dir=path())
+    with cmdb('accounts') as path:
+        account.run(**conf['cmdb']['account'], output_dir=path())
+    with cmdb() as path:
+        base.run(**conf['cmdb']['product'], output_dir=path())
     with cmdb('accounts', tenant_name):
         with open('domains.json', 'rb') as domains_file:
             domains_json = json.load(domains_file)

--- a/hamlet-cli/tests/system/cmdb/alm/step_1_create_cmdb.py
+++ b/hamlet-cli/tests/system/cmdb/alm/step_1_create_cmdb.py
@@ -7,13 +7,13 @@ from .conftest import conf
 
 def run(cmdb, clear_cmdb):
     clear_cmdb()
-    with cmdb():
+    with cmdb() as path:
         os.mknod('root.json')
-        tenant.run(**conf['cmdb']['tenant'])
-    with cmdb('accounts'):
-        account.run(**conf['cmdb']['account'])
-    with cmdb():
-        app_lifecycle_mgmt.run(**conf['cmdb']['product'])
+        tenant.run(**conf['cmdb']['tenant'], output_dir=path())
+    with cmdb('accounts') as path:
+        account.run(**conf['cmdb']['account'], output_dir=path())
+    with cmdb() as path:
+        app_lifecycle_mgmt.run(**conf['cmdb']['product'], output_dir=path())
     with cmdb('accounts', 'tenant'):
         with open('domains.json', 'rb') as domains_file:
             domains_json = json.load(domains_file)

--- a/hamlet-cli/tests/unit/command/generate/cmdb/test_account.py
+++ b/hamlet-cli/tests/unit/command/generate/cmdb/test_account.py
@@ -9,7 +9,7 @@ OPTIONS['!--account-id,account_id'] = 'test-account-id'
 OPTIONS['!--provider-id,provider_id'] = 'test-provider-id'
 OPTIONS['--account-name,account_name'] = ('test-account-name', 'test-account-id')
 OPTIONS['--account-seed,account_seed'] = ('not-random-seed', 'random-seed')
-OPTIONS['--provider-type,provider_type'] = ('not-test-provider-type', 'test-provider-type')
+OPTIONS['--provider-type,provider_type'] = ('aws', 'azure')
 
 
 @mock.patch('hamlet.command.generate.cmdb.generate_account_backend')

--- a/hamlet-cli/tests/unit/command/generate/cmdb/test_tenant.py
+++ b/hamlet-cli/tests/unit/command/generate/cmdb/test_tenant.py
@@ -7,7 +7,6 @@ from tests.unit.command.generate.test_generate_command import run_generate_comma
 OPTIONS = collections.OrderedDict()
 OPTIONS['!--tenant-id,tenant_id'] = 'test-tenant-id'
 OPTIONS['--tenant-name,tenant_name'] = ('test-tenant-name', 'test-tenant-id')
-OPTIONS['--domain-stem,domain_stem'] = ('codeontap.io', '')
 OPTIONS['--default-region,default_region'] = ('ap-southwest-1', 'ap-southeast-2')
 OPTIONS['--audit-log-expiry-days,audit_log_expiry_days'] = (10, 2555)
 OPTIONS['--audit-log-offline-days,audit_log_offline_days'] = (11, 90)

--- a/hamlet-cli/tests/unit/command/generate/product/test_base.py
+++ b/hamlet-cli/tests/unit/command/generate/product/test_base.py
@@ -7,11 +7,9 @@ from tests.unit.command.generate.test_generate_command import run_generate_comma
 OPTIONS = collections.OrderedDict()
 OPTIONS['!--product-id,product_id'] = 'test-product-id'
 OPTIONS['--product-name,product_name'] = ('test-product-name', 'test-product-id')
-OPTIONS['--domain-id,domain_id'] = ('test-domain-id', '')
-OPTIONS['!--solution-id,solution_id'] = 'test-solution-id'
-OPTIONS['--solution-name,solution_name'] = ('test-solution-name', 'test-solution-id')
-OPTIONS['!--environment-id,environment_id'] = 'test-environment-id'
-OPTIONS['--environment-name,environment_name'] = ('test-environment-name', 'test-environment-id')
+OPTIONS['--dns-zone,dns_zone'] = ('test-zone-name', '')
+OPTIONS['--environment-id,environment_id'] = ('test-environment-id', 'test-environment-id')
+OPTIONS['--environment-name,environment_name'] = ('test-environment-name', 'test-environment-name')
 OPTIONS['--segment-id,segment_id'] = ('test-segment-id', 'default')
 OPTIONS['--segment-name,segment_name'] = ('test-segment-name', 'default')
 

--- a/hamlet-cli/tests/unit/command/generate/test_generate_command.py
+++ b/hamlet-cli/tests/unit/command/generate/test_generate_command.py
@@ -48,8 +48,8 @@ def __get_default(values):
 
 def __generate_prompt_options_testcase(template):
     for required_only in [True, False]:
-        options = ['--prompt']
-        options_str = [options[0]]
+        options = []
+        options_str = []
         if required_only:
             options.append('--use-default')
             options_str.append(options[-1])


### PR DESCRIPTION
## Description

- Adds output_dir control for generate commands ( defaults to cwd)
- Changes prompt behaviour to on by default. Adds --np-prompt to align
with the rest of the cli
- handling of existing directory errors which are common for users
- option help for generate commands which are used a lot

## Motivation and Context

Quality of life improvements identified by the team after using the generate command

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
