### PR TITLE
feat: setup command

### DIFF
--- a/hamlet-cli/hamlet/__init__.py
+++ b/hamlet-cli/hamlet/__init__.py
@@ -10,4 +10,4 @@ import hamlet.command.query  # noqa
 import hamlet.command.visual  # noqa
 import hamlet.command.deploy  # noqa
 import hamlet.command.schema  # noqa
-import hamlet.command.setup  #noqa
+import hamlet.command.setup  # noqa

--- a/hamlet-cli/hamlet/__init__.py
+++ b/hamlet-cli/hamlet/__init__.py
@@ -10,3 +10,4 @@ import hamlet.command.query  # noqa
 import hamlet.command.visual  # noqa
 import hamlet.command.deploy  # noqa
 import hamlet.command.schema  # noqa
+import hamlet.command.setup  #noqa

--- a/hamlet-cli/hamlet/backend/setup/__init__.py
+++ b/hamlet-cli/hamlet/backend/setup/__init__.py
@@ -1,0 +1,8 @@
+from hamlet.backend.common import runner
+
+
+def run(
+    _is_cli=False
+):
+    options = {}
+    runner.run('setup.sh', [], options, _is_cli)

--- a/hamlet-cli/hamlet/command/setup/__init__.py
+++ b/hamlet-cli/hamlet/command/setup/__init__.py
@@ -1,9 +1,8 @@
-import click
-
 from hamlet.command import root as cli
 from hamlet.command.common.exceptions import CommandError
 from hamlet.backend import setup as setup_backend
 from hamlet.backend.common.exceptions import BackendException
+
 
 @cli.command(
     'setup',

--- a/hamlet-cli/hamlet/command/setup/__init__.py
+++ b/hamlet-cli/hamlet/command/setup/__init__.py
@@ -1,0 +1,23 @@
+import click
+
+from hamlet.command import root as cli
+from hamlet.command.common.exceptions import CommandError
+from hamlet.backend import setup as setup_backend
+from hamlet.backend.common.exceptions import BackendException
+
+@cli.command(
+    'setup',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+def setup(**kwargs):
+    '''
+    Sets up the local hamlet workspace
+    '''
+    try:
+        setup_backend.run(**kwargs, _is_cli=True)
+
+    except BackendException as e:
+        raise CommandError(str(e))


### PR DESCRIPTION
## Description
Adds the ${GENERATION_DIR}/setup.sh command from the bash executor into the cli

## Motivation and Context
This command is currently used for installing the required plugins defined in a CMDB. This makes it easy to manage the plugin and setup installation process

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
