### PR TITLE
feat: add root_dir as common option

### DIFF
--- a/hamlet-cli/hamlet/command/common/config.py
+++ b/hamlet-cli/hamlet/command/common/config.py
@@ -1,6 +1,9 @@
 import click
 import os
 
+from click_configfile import ConfigFileReadeosr, Param, SectionSchema, matches_section
+
+
 from click_configfile import ConfigFileReader, Param, SectionSchema, matches_section
 
 

--- a/hamlet-cli/hamlet/command/common/config.py
+++ b/hamlet-cli/hamlet/command/common/config.py
@@ -1,9 +1,6 @@
 import click
 import os
 
-from click_configfile import ConfigFileReadeosr, Param, SectionSchema, matches_section
-
-
 from click_configfile import ConfigFileReader, Param, SectionSchema, matches_section
 
 

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -41,6 +41,11 @@ def common_district_options(f):
     """Common options for district config"""
 
     @click.option(
+        "--root-dir",
+        envvar="ROOT_DIR",
+        help="The root CMDB directory",
+    )
+    @click.option(
         "--tenant",
         envvar="TENANT",
         help="The tenant id to use",
@@ -72,6 +77,7 @@ def common_district_options(f):
         District options from cmd line or file
         '''
         opts = ctx.ensure_object(Options)
+        opts.root_dir = kwargs.pop("root_dir")
         opts.tenant = kwargs.pop("tenant")
         opts.account = kwargs.pop("account")
         opts.product = kwargs.pop("product")

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -54,7 +54,6 @@ def common_district_options(f):
         "--account",
         envvar="ACCOUNT",
         help="The account name to use",
-        required=True,
     )
     @click.option(
         "--product",

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -43,32 +43,33 @@ def common_district_options(f):
     @click.option(
         "--root-dir",
         envvar="ROOT_DIR",
-        help="The root CMDB directory",
+        help="The root CMDB directory (default: CMDB current location)",
     )
     @click.option(
         "--tenant",
         envvar="TENANT",
-        help="The tenant id to use",
+        help="The tenant name to use (default: CMDB current location)",
     )
     @click.option(
         "--account",
         envvar="ACCOUNT",
-        help="The account id to use",
+        help="The account name to use",
+        required=True,
     )
     @click.option(
         "--product",
         envvar="PRODUCT",
-        help="The product id to use",
+        help="The product name to use (default: CMDB current location)",
     )
     @click.option(
         "--environment",
         envvar="ENVIRONMENT",
-        help="The environment id to use",
+        help="The environment name to use (default: CMDB current location)",
     )
     @click.option(
         "--segment",
         envvar="SEGMENT",
-        help="The segment id to use",
+        help="The segment name to use (default: CMDB current location)"
     )
     @click.pass_context
     @functools.wraps(f)


### PR DESCRIPTION

## Description

- adds the root_dir to the common district configuration
- linting fixes in files related to this configuration option

## Motivation and Context

This is a common configuration option and is required when working outside of a cmdb directory 

## How Has This Been Tested?
Tested locally and using test suite

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
