### PR TITLE
fix: output_dir paramter not required

### DIFF
--- a/hamlet-cli/hamlet/command/generate/product.py
+++ b/hamlet-cli/hamlet/command/generate/product.py
@@ -56,7 +56,6 @@ def group():  # pragma: no cover
 @click.pass_context
 def generate_base(
     ctx,
-    output_dir=None,
     prompt=None,
     use_default=None,
     **kwargs
@@ -141,7 +140,6 @@ def generate_base(
 @click.pass_context
 def generate_app_lifecycle_mgmt(
     ctx,
-    output_dir=None,
     prompt=None,
     use_default=None,
     **kwargs


### PR DESCRIPTION
## Description

Fixes #91 - Which will pass the output_dir down to the cookiecutter util as part of the **kwargs catch all parameter on the command function. 

## Motivation and Context

Generation of template was failing

## How Has This Been Tested?

Tested locally and with test suite 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
