### PR TITLE
feat: Deployment state support

### DIFF
--- a/hamlet-cli/hamlet/backend/manage/credential_crypto/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/credential_crypto/__init__.py
@@ -16,7 +16,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs,
 ):
     options = {
         '-e': credential_email,

--- a/hamlet-cli/hamlet/backend/manage/crypto/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/crypto/__init__.py
@@ -21,7 +21,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs,
 ):
     options = {
         '-a': alias,

--- a/hamlet-cli/hamlet/backend/manage/deployment/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/deployment/__init__.py
@@ -20,7 +20,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs,
 ):
     options = {
         '-d': delete,

--- a/hamlet-cli/hamlet/backend/manage/file_crypto/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/file_crypto/__init__.py
@@ -13,7 +13,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs,
 ):
     options = {
         '-d': decrypt,

--- a/hamlet-cli/hamlet/backend/manage/stack/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/stack/__init__.py
@@ -20,7 +20,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs,
 ):
     options = {
         '-d': delete,

--- a/hamlet-cli/hamlet/command/manage/credentials_crypto.py
+++ b/hamlet-cli/hamlet/command/manage/credentials_crypto.py
@@ -2,6 +2,7 @@ import click
 from hamlet.backend.manage import credential_crypto as manage_credentials_crypto_backend
 from hamlet.backend.common.exceptions import BackendException
 from hamlet.command.common.exceptions import CommandError
+from hamlet.command.common.config import pass_options
 
 
 @click.command(
@@ -63,7 +64,8 @@ from hamlet.command.common.exceptions import CommandError
         case_sensitive=False
     )
 )
-def credentials_crypto(**kwargs):
+@pass_options
+def credentials_crypto(options, **kwargs):
     """
     Manage crypto for credential storage
 
@@ -75,8 +77,14 @@ def credentials_crypto(**kwargs):
     4. For CREDENTIAL_TYPE of ${CREDENTIAL_TYPE_API}, Id Attribute = AccessKey, Secret Attribute = SecretKey
     5. For CREDENTIAL_TYPE of ${CREDENTIAL_TYPE_ENV}, Id Attribute = ACCESS_KEY, Secret Attribute = SECRET_KEY
     """
+
+    args = {
+        **options.opts,
+        **kwargs
+    }
+
     try:
-        manage_credentials_crypto_backend.run(**kwargs, _is_cli=True)
+        manage_credentials_crypto_backend.run(**args, _is_cli=True)
 
     except BackendException as e:
         raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/crypto.py
+++ b/hamlet-cli/hamlet/command/manage/crypto.py
@@ -2,6 +2,7 @@ import click
 from hamlet.backend.manage import crypto as manage_crypto_backend
 from hamlet.backend.common.exceptions import BackendException
 from hamlet.command.common.exceptions import CommandError
+from hamlet.command.common.config import pass_options
 
 
 @click.command(
@@ -84,7 +85,8 @@ from hamlet.command.common.exceptions import CommandError
     help='result is base64 decoded (visible)',
     is_flag=True
 )
-def crypto(**kwargs):
+@pass_options
+def crypto(options, **kwargs):
     """
     Manage cryptographic operations using KMS
 
@@ -115,8 +117,14 @@ def crypto(**kwargs):
        visibility flag is set
     8. Decrypted files will have a ".decrypted" extension added so they can be ignored by git
     """
+
+    args = {
+        **options.opts,
+        **kwargs
+    }
+
     try:
-        manage_crypto_backend.run(**kwargs, _is_cli=True)
+        manage_crypto_backend.run(**args, _is_cli=True)
 
     except BackendException as e:
         raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/deployment.py
+++ b/hamlet-cli/hamlet/command/manage/deployment.py
@@ -2,6 +2,7 @@ import click
 from hamlet.backend.manage import deployment as manage_deployment_backend
 from hamlet.backend.common.exceptions import BackendException
 from hamlet.command.common.exceptions import CommandError
+from hamlet.command.common.config import pass_options
 
 
 @click.command(
@@ -78,11 +79,18 @@ from hamlet.command.common.exceptions import CommandError
     '--deployment-unit-subset',
     help='subset of the deployment unit required'
 )
-def deployment(**kwargs):
+@pass_options
+def deployment(options, **kwargs):
     """
     Manage an Azure Resource Manager (ARM) deployment
     """
+
+    args = {
+        **options.opts,
+        **kwargs
+    }
+
     try:
-        manage_deployment_backend.run(**kwargs, _is_cli=True)
+        manage_deployment_backend.run(**args, _is_cli=True)
     except BackendException as e:
         raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/file_crypto.py
+++ b/hamlet-cli/hamlet/command/manage/file_crypto.py
@@ -2,7 +2,7 @@ import click
 from hamlet.backend.manage import file_crypto as manage_file_crypto_backend
 from hamlet.backend.common.exceptions import BackendException
 from hamlet.command.common.exceptions import CommandError
-
+from hamlet.command.common.config import pass_options
 
 @click.command(
     'file-crypto',
@@ -40,7 +40,8 @@ from hamlet.command.common.exceptions import CommandError
     is_flag=True,
     help='update the file'
 )
-def file_crypto(**kwargs):
+@pass_options
+def file_crypto(options, **kwargs):
     """
     Manage crypto for files
 
@@ -48,7 +49,13 @@ def file_crypto(**kwargs):
     NOTES:
     1. If no operation is provided, the current file contents are displayed
     """
+
+    args = {
+        **options.opts,
+        **kwargs
+    }
+
     try:
-        manage_file_crypto_backend.run(**kwargs, _is_cli=True)
+        manage_file_crypto_backend.run(**args, _is_cli=True)
     except BackendException as e:
         raise CommandError(str(e))

--- a/hamlet-cli/hamlet/command/manage/stack.py
+++ b/hamlet-cli/hamlet/command/manage/stack.py
@@ -2,6 +2,7 @@ import click
 from hamlet.backend.manage import stack as manage_stack_backend
 from hamlet.backend.common.exceptions import BackendException
 from hamlet.command.common.exceptions import CommandError
+from hamlet.command.common.config import pass_options
 
 
 @click.command(
@@ -65,7 +66,8 @@ from hamlet.command.common.exceptions import CommandError
     is_flag=True,
     help='show what will happen without actually updating the stack'
 )
-def stack(**kwargs):
+@pass_options
+def stack(options, **kwargs):
     """
     Manage a CloudFormation stack
 
@@ -79,8 +81,14 @@ def stack(**kwargs):
     6. A dryrun creates a change set, then displays it. It only applies when
        the STACK_OPERATION=update
     """
+
+    args = {
+        **options.opts,
+        **kwargs
+    }
+
     try:
-        manage_stack_backend.run(**kwargs, _is_cli=True)
+        manage_stack_backend.run(**args, _is_cli=True)
 
     except BackendException as e:
         raise CommandError(str(e))

--- a/hamlet-cli/tests/unit/command/deploy/test_deploy.py
+++ b/hamlet-cli/tests/unit/command/deploy/test_deploy.py
@@ -14,6 +14,7 @@ ALL_VALID_OPTIONS['-o,--output-dir'] = 'output_dir'
 ALL_VALID_OPTIONS['-u,--deployment-unit'] = 'DeploymentUnit1'
 ALL_VALID_OPTIONS['-l,--deployment-group'] = 'DeploymentGroup1'
 ALL_VALID_OPTIONS['-m,--deployment-mode'] = 'deployment_mode'
+ALL_VALID_OPTIONS['-s,--deployment-state'] = 'deployed'
 ALL_VALID_OPTIONS['--refresh-outputs'] = True
 ALL_VALID_OPTIONS['--confirm'] = True
 
@@ -74,7 +75,8 @@ unit_list = {
                         'DeploymentUnit': 'DeploymentUnit1',
                         'DeploymentGroup': 'DeploymentGroup1',
                         'DeploymentProvider': 'aws',
-                        'Operations': ['Operation11']
+                        'Operations': ['Operation11'],
+                        'CurrentState' : 'deployed'
                     }
                 },
                 {
@@ -83,7 +85,8 @@ unit_list = {
                         'DeploymentUnit': 'DeploymentUnit2',
                         'DeploymentGroup': 'DeploymentGroup2',
                         'DeploymentProvider': 'aws',
-                        'Operations': ['Operation21']
+                        'Operations': ['Operation21'],
+                        'CurrentState' : 'deployed'
                     }
                 }
             ]
@@ -108,6 +111,7 @@ def test_input_validation(blueprint_mock, ContextClassMock, create_template_back
             '-m': 'DeploymentMode1',
             '-l': 'DeploymentGroup1',
             '-u': 'DeploymentUnit1',
+            '-s': 'deployed',
         },
         []
     )

--- a/hamlet-cli/tests/unit/command/deploy/test_list.py
+++ b/hamlet-cli/tests/unit/command/deploy/test_list.py
@@ -62,7 +62,8 @@ def mock_backend(unitlist=None):
                             'DeploymentUnit': 'DeploymentUnit[1]',
                             'DeploymentGroup': 'DeploymentGroup[1]',
                             'DeploymentProvider': 'DeploymentProvider[1]',
-                            'Operations': ['Operation[1]']
+                            'Operations': ['Operation[1]'],
+                            'CurrentState' : 'deployed'
                         }
                     },
                     {
@@ -71,7 +72,8 @@ def mock_backend(unitlist=None):
                             'DeploymentUnit': 'DeploymentUnit[2]',
                             'DeploymentGroup': 'DeploymentGroup[2]',
                             'DeploymentProvider': 'DeploymentProvider[2]',
-                            'Operations': ['Operation[2]']
+                            'Operations': ['Operation[2]'],
+                            'CurrentState' : 'deployed',
                         }
                     }
                 ]
@@ -85,7 +87,8 @@ def mock_backend(unitlist=None):
                             'DeploymentUnit': 'DeploymentUnit[3]',
                             'DeploymentGroup': 'DeploymentGroup[3]',
                             'DeploymentProvider': 'DeploymentProvider[3]',
-                            'Operations': ['Operation[3]']
+                            'Operations': ['Operation[3]'],
+                            'CurrentState' : 'deployed',
                         }
                     },
                     {
@@ -94,7 +97,8 @@ def mock_backend(unitlist=None):
                             'DeploymentUnit': 'DeploymentUnit[4]',
                             'DeploymentGroup': 'DeploymentGroup[4]',
                             'DeploymentProvider': 'DeploymentProvider[4]',
-                            'Operations': ['Operation[4]']
+                            'Operations': ['Operation[4]'],
+                            'CurrentState' : 'deployed',
                         }
                     }
                 ]
@@ -119,23 +123,27 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         'DeploymentUnit': 'DeploymentUnit[1]',
         'DeploymentGroup': 'DeploymentGroup[1]',
         'DeploymentProvider': 'DeploymentProvider[1]',
-        'Operations': ['Operation[1]']
+        'Operations': ['Operation[1]'],
+        'CurrentState' : 'deployed',
     } in result
     assert {
         'DeploymentUnit': 'DeploymentUnit[2]',
         'DeploymentGroup': 'DeploymentGroup[2]',
         'DeploymentProvider': 'DeploymentProvider[2]',
-        'Operations': ['Operation[2]']
+        'Operations': ['Operation[2]'],
+        'CurrentState' : 'deployed',
     } in result
     assert {
         'DeploymentUnit': 'DeploymentUnit[3]',
         'DeploymentGroup': 'DeploymentGroup[3]',
         'DeploymentProvider': 'DeploymentProvider[3]',
-        'Operations': ['Operation[3]']
+        'Operations': ['Operation[3]'],
+        'CurrentState' : 'deployed',
     } in result
     assert {
         'DeploymentUnit': 'DeploymentUnit[4]',
         'DeploymentGroup': 'DeploymentGroup[4]',
         'DeploymentProvider': 'DeploymentProvider[4]',
-        'Operations': ['Operation[4]']
+        'Operations': ['Operation[4]'],
+        'CurrentState' : 'deployed',
     } in result


### PR DESCRIPTION
## Description

Adds support for filtering deployments based on their current state. 
Includes run-deployment handling for remove orphan deployments as part of the process. This will skip template generation and show a warning message if an orphan resource is being processed as part of deployment run 

All of the deploy group command now includes a new option -s/--deployment-state which defaults to `deployed` and `notdeployed`. This aligns with the current state of the deployment processing 

On list and run there is an additional state value called `orphaned` which can be used to show deployments which shouldn't be active and allows you to perform cleanups as required

Also adds env options to the manage commands as this was missed before.

## Motivation and Context

Implements https://github.com/hamlet-io/engine/pull/1574 for the cli 

This allows you to find out which deployments are currently active and which ones need to be deployed. You can also choose to filter deployment runs based on the deployment state. 


## How Has This Been Tested?

Testing run locally and test suite update

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] Requires: https://github.com/hamlet-io/engine/pull/1574

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
