### PR TITLE
feat: Component command group

### DIFF
--- a/hamlet-cli/hamlet/__init__.py
+++ b/hamlet-cli/hamlet/__init__.py
@@ -11,3 +11,4 @@ import hamlet.command.visual  # noqa
 import hamlet.command.deploy  # noqa
 import hamlet.command.schema  # noqa
 import hamlet.command.setup  # noqa
+import hamlet.command.component # noqa

--- a/hamlet-cli/hamlet/backend/query/__init__.py
+++ b/hamlet-cli/hamlet/backend/query/__init__.py
@@ -52,10 +52,10 @@ def run(
     if query_name is not None:
         result = query.query_by_name(query_name, query_params or {})
     elif query_text is not None:
-        result = query.query(query_text)
+        result = query.query(query_text, query_params or {})
     else:
         raise exceptions.BackendException("Query unspecified")
-    if sub_query_text:
+    if sub_query_text is not None:
         result = query.perform_query(sub_query_text, result)
     return result
 

--- a/hamlet-cli/hamlet/command/common/display.py
+++ b/hamlet-cli/hamlet/command/common/display.py
@@ -18,7 +18,7 @@ def wrap_text(text):
 
 def table_from_dict(data):
     '''
-    createas a table of k,v pairs from a list of dicts
+    creates a table of k,v pairs from a list of dicts
     '''
     tablerows = []
     for k, v in data.items():

--- a/hamlet-cli/hamlet/command/common/display.py
+++ b/hamlet-cli/hamlet/command/common/display.py
@@ -16,14 +16,13 @@ def wrap_text(text):
     return "\n".join(textwrap.wrap(text, MAX_TABLE_TEXT_CONTENT_WIDTH))
 
 
-def table_from_list_dict(data):
+def table_from_dict(data):
     '''
     createas a table of k,v pairs from a list of dicts
     '''
     tablerows = []
-    for result in data:
-        for k,v in result.items():
-            tablerows.append([wrap_text(k), wrap_text(v)])
+    for k, v in data.items():
+        tablerows.append([wrap_text(k), wrap_text(v)])
     return tabulate(
         tablerows,
         headers=['Key', 'Value'],

--- a/hamlet-cli/hamlet/command/common/display.py
+++ b/hamlet-cli/hamlet/command/common/display.py
@@ -3,6 +3,7 @@ import functools
 import json
 import textwrap
 
+from tabulate import tabulate
 
 MAX_TABLE_TEXT_CONTENT_WIDTH = 128
 
@@ -13,6 +14,21 @@ def wrap_text(text):
     if isinstance(text, int):
         return text
     return "\n".join(textwrap.wrap(text, MAX_TABLE_TEXT_CONTENT_WIDTH))
+
+
+def table_from_list_dict(data):
+    '''
+    createas a table of k,v pairs from a list of dicts
+    '''
+    tablerows = []
+    for result in data:
+        for k,v in result.items():
+            tablerows.append([wrap_text(k), wrap_text(v)])
+    return tabulate(
+        tablerows,
+        headers=['Key', 'Value'],
+        tablefmt="github"
+    )
 
 
 def json_or_table_option(tablefunc):

--- a/hamlet-cli/hamlet/command/component/__init__.py
+++ b/hamlet-cli/hamlet/command/component/__init__.py
@@ -5,12 +5,12 @@ from hamlet.command.component.list_occurrences import list_occurrences as list_o
 
 
 @cli.group('component')
-def group():
+def component_group():
     """
     Provides information on the components used in a hamlet
     """
     pass
 
 
-group.add_command(describe_occurrence_group)
-group.add_command(list_occurrences_command)
+component_group.add_command(describe_occurrence_group)
+component_group.add_command(list_occurrences_command)

--- a/hamlet-cli/hamlet/command/component/__init__.py
+++ b/hamlet-cli/hamlet/command/component/__init__.py
@@ -1,0 +1,16 @@
+from hamlet.command import root as cli
+
+from hamlet.command.component.describe_occurrence import describe_occurrence as describe_occurrence_group
+from hamlet.command.component.list_occurrences import list_occurrences as list_occurrences_command
+
+
+@cli.group('component')
+def group():
+    """
+    Provides information on the components used in a hamlet
+    """
+    pass
+
+
+group.add_command(describe_occurrence_group)
+group.add_command(list_occurrences_command)

--- a/hamlet-cli/hamlet/command/component/common.py
+++ b/hamlet-cli/hamlet/command/component/common.py
@@ -1,0 +1,31 @@
+import os
+from hamlet.backend import query as query_backend
+
+
+class DescribeContext():
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+
+def query_occurrences_state(options, query, query_params=None, sub_query_text=None):
+    query_args = {
+        **options.opts,
+        'generation_entrance': 'occurrences',
+        'output_filename': 'occurrences-state.json',
+        'use_cache': False,
+    }
+    query_result = query_backend.run(
+        **query_args,
+        cwd=os.getcwd(),
+        query_text=query,
+        query_params=query_params,
+        sub_query_text=sub_query_text
+    )
+
+    return query_result

--- a/hamlet-cli/hamlet/command/component/describe_occurrence.py
+++ b/hamlet-cli/hamlet/command/component/describe_occurrence.py
@@ -1,0 +1,134 @@
+import click
+import json
+
+from hamlet.command.common import exceptions, config
+from hamlet.command.common.display import json_or_table_option, table_from_list_dict
+
+from .common import query_occurrences_state, DescribeContext
+
+
+DESCRIBE_OCCURRENCE_QUERY = (
+    "Occurrences[?Core.Name=={name}] | [0]"
+)
+
+
+def query_occurrence_state(ctx, query=None):
+    '''
+    Query the state of a single occurrence
+    '''
+    options_context = ctx.ensure_object(config.Options)
+    describe_context = ctx.ensure_object(DescribeContext)
+
+    query_result = query_occurrences_state(
+        options=options_context,
+        query=DESCRIBE_OCCURRENCE_QUERY,
+        query_params={
+            'name': describe_context.name
+        },
+        sub_query_text=query
+    )
+
+    return query_result
+
+
+@click.group(
+    'describe-occurrence',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    ),
+    invoke_without_command=True
+)
+@click.option(
+    '-n',
+    '--name',
+    required=True,
+    help='The name of the occurrence to describe'
+)
+@click.option(
+    '-q',
+    '--query',
+    help='A JMESPath query to apply to the results',
+)
+@exceptions.backend_handler()
+@click.pass_context
+def describe_occurrence(ctx, name, query):
+    """
+    Describe an occurrence
+    """
+
+    describe_context = DescribeContext()
+    describe_context.name = name
+    ctx.obj = describe_context
+
+    if ctx.invoked_subcommand is None:
+        click.echo(json.dumps(query_occurrence_state(ctx, query), indent=4))
+
+
+@describe_occurrence.command(
+    'solution',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.pass_context
+def describe_occurrence_solution(ctx):
+    '''
+    Predefined query:
+    The evaluated solution configuration for the occurrence
+    '''
+    result = query_occurrence_state(ctx, 'Configuration.Solution')
+    click.echo(json.dumps(result, indent=4))
+
+
+@describe_occurrence.command(
+    'resources',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.pass_context
+def describe_occurrence_resources(ctx):
+    '''
+    Predefined query:
+    The resources of the occurrence
+    '''
+    result = query_occurrence_state(ctx, 'State.Resources')
+    click.echo(json.dumps(result, indent=4))
+
+
+@describe_occurrence.command(
+    'setting-namespaces',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.pass_context
+def describe_occurrence_setting_namespaces(ctx):
+    '''
+    Predefined query:
+    The setting namespaces for the occurrence
+    '''
+    result = query_occurrence_state(ctx, 'Configuration.SettingNamespaces')
+    click.echo(json.dumps(result, indent=4))
+
+
+@describe_occurrence.command(
+    'attributes',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@json_or_table_option(table_from_list_dict)
+@click.pass_context
+def describe_occurrence_attributes(ctx):
+    '''
+    Predefined query:
+    The attributes for the occurrence
+    '''
+    result = query_occurrence_state(ctx, 'State.ResourceGroups.*[].Attributes[]')
+    return result

--- a/hamlet-cli/hamlet/command/component/describe_occurrence.py
+++ b/hamlet-cli/hamlet/command/component/describe_occurrence.py
@@ -1,7 +1,7 @@
 import click
 import json
 
-from hamlet.command.common import config
+from hamlet.command.common import config, exceptions
 from hamlet.command.common.display import json_or_table_option, table_from_dict
 
 from .common import query_occurrences_state, DescribeContext
@@ -50,6 +50,7 @@ def query_occurrence_state(ctx, query=None):
     '--query',
     help='A JMESPath query to apply to the results',
 )
+@exceptions.backend_handler()
 @click.pass_context
 def describe_occurrence(ctx, name, query):
     """
@@ -71,6 +72,7 @@ def describe_occurrence(ctx, name, query):
         max_content_width=240
     )
 )
+@exceptions.backend_handler()
 @click.pass_context
 def describe_occurrence_solution(ctx):
     '''
@@ -88,6 +90,7 @@ def describe_occurrence_solution(ctx):
         max_content_width=240
     )
 )
+@exceptions.backend_handler()
 @click.pass_context
 def describe_occurrence_resources(ctx):
     '''
@@ -105,6 +108,7 @@ def describe_occurrence_resources(ctx):
         max_content_width=240
     )
 )
+@exceptions.backend_handler()
 @click.pass_context
 def describe_occurrence_setting_namespaces(ctx):
     '''
@@ -123,6 +127,7 @@ def describe_occurrence_setting_namespaces(ctx):
     )
 )
 @json_or_table_option(table_from_dict)
+@exceptions.backend_handler()
 @click.pass_context
 def describe_occurrence_attributes(ctx):
     '''

--- a/hamlet-cli/hamlet/command/component/describe_occurrence.py
+++ b/hamlet-cli/hamlet/command/component/describe_occurrence.py
@@ -1,8 +1,8 @@
 import click
 import json
 
-from hamlet.command.common import exceptions, config
-from hamlet.command.common.display import json_or_table_option, table_from_list_dict
+from hamlet.command.common import config
+from hamlet.command.common.display import json_or_table_option, table_from_dict
 
 from .common import query_occurrences_state, DescribeContext
 
@@ -50,7 +50,6 @@ def query_occurrence_state(ctx, query=None):
     '--query',
     help='A JMESPath query to apply to the results',
 )
-@exceptions.backend_handler()
 @click.pass_context
 def describe_occurrence(ctx, name, query):
     """
@@ -123,12 +122,12 @@ def describe_occurrence_setting_namespaces(ctx):
         max_content_width=240
     )
 )
-@json_or_table_option(table_from_list_dict)
+@json_or_table_option(table_from_dict)
 @click.pass_context
 def describe_occurrence_attributes(ctx):
     '''
     Predefined query:
     The attributes for the occurrence
     '''
-    result = query_occurrence_state(ctx, 'State.ResourceGroups.*[].Attributes[]')
+    result = query_occurrence_state(ctx, 'State.Attributes')
     return result

--- a/hamlet-cli/hamlet/command/component/list_occurrences.py
+++ b/hamlet-cli/hamlet/command/component/list_occurrences.py
@@ -1,0 +1,64 @@
+import click
+import re
+
+from tabulate import tabulate
+
+from hamlet.command.common import exceptions
+from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common.config import pass_options
+
+from .common import query_occurrences_state
+
+LIST_OCCURRENCES_QUERY = (
+    'Occurrences[]'
+    '.{'
+    'TierId:Core.Tier.Id,'
+    'ComponentId:Core.Component.Id,'
+    'Name:Core.Name,'
+    'Type:Core.Type'
+    '}'
+)
+
+
+def list_occurrences_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row['TierId']),
+                wrap_text(row['ComponentId']),
+                wrap_text(row['Name']),
+                wrap_text(row['Type']),
+            ]
+        )
+    return tabulate(
+        tablerows,
+        headers=['TierId', 'ComponentId', 'Name', 'Type'],
+        tablefmt='github'
+    )
+
+
+@click.command(
+    'list-occurrences',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.option(
+    '-q',
+    '--query',
+    help='A JMESPath query to apply to the results',
+)
+@json_or_table_option(list_occurrences_table)
+@exceptions.backend_handler()
+@pass_options
+def list_occurrences(options, query):
+    """
+    List available occurrences
+    """
+    return query_occurrences_state(
+                options=options,
+                query=LIST_OCCURRENCES_QUERY,
+                sub_query_text=query
+            )

--- a/hamlet-cli/hamlet/command/component/list_occurrences.py
+++ b/hamlet-cli/hamlet/command/component/list_occurrences.py
@@ -4,6 +4,7 @@ from tabulate import tabulate
 
 from hamlet.command.common.display import json_or_table_option, wrap_text
 from hamlet.command.common.config import pass_options
+from hamlet.command.common import exceptions
 
 from .common import query_occurrences_state
 
@@ -49,6 +50,7 @@ def list_occurrences_table(data):
     help='A JMESPath query to apply to the results',
 )
 @json_or_table_option(list_occurrences_table)
+@exceptions.backend_handler()
 @pass_options
 def list_occurrences(options, query):
     """

--- a/hamlet-cli/hamlet/command/component/list_occurrences.py
+++ b/hamlet-cli/hamlet/command/component/list_occurrences.py
@@ -1,9 +1,7 @@
 import click
-import re
 
 from tabulate import tabulate
 
-from hamlet.command.common import exceptions
 from hamlet.command.common.display import json_or_table_option, wrap_text
 from hamlet.command.common.config import pass_options
 
@@ -51,14 +49,13 @@ def list_occurrences_table(data):
     help='A JMESPath query to apply to the results',
 )
 @json_or_table_option(list_occurrences_table)
-@exceptions.backend_handler()
 @pass_options
 def list_occurrences(options, query):
     """
     List available occurrences
     """
     return query_occurrences_state(
-                options=options,
-                query=LIST_OCCURRENCES_QUERY,
-                sub_query_text=query
-            )
+        options=options,
+        query=LIST_OCCURRENCES_QUERY,
+        sub_query_text=query
+    )

--- a/hamlet-cli/hamlet/command/component/list_occurrences.py
+++ b/hamlet-cli/hamlet/command/component/list_occurrences.py
@@ -12,7 +12,7 @@ LIST_OCCURRENCES_QUERY = (
     'Occurrences[]'
     '.{'
     'TierId:Core.Tier.Id,'
-    'ComponentId:Core.Component.Id,'
+    'ComponentId:Core.Component.RawId,'
     'Name:Core.Name,'
     'Type:Core.Type'
     '}'

--- a/hamlet-cli/tests/unit/command/component/test_occurrence.py
+++ b/hamlet-cli/tests/unit/command/component/test_occurrence.py
@@ -1,0 +1,266 @@
+import os
+import hashlib
+import json
+import tempfile
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.component.describe_occurrence import describe_occurrence
+from hamlet.command.component.list_occurrences import list_occurrences
+
+from hamlet.command.component.common import DescribeContext
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance='occurrences',
+        output_filename='occurrences-state.json',
+        output_dir=None,
+        deployment_mode=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        blueprint_filename = os.path.join(output_dir, output_filename)
+        with open(blueprint_filename, 'wt+') as f:
+            json.dump(data, f)
+    return run
+
+
+def mock_backend(blueprint=None):
+    def decorator(func):
+        @mock.patch('hamlet.backend.query.context.Context')
+        @mock.patch('hamlet.backend.query.template')
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(hashlib.md5(str(blueprint).encode()).hexdigest())
+                ContextObjectMock.cache_dir = temp_cache_dir
+
+                blueprint_mock.run.side_effect = template_backend_run_mock(blueprint)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+def mock_describe_context(name=None):
+    def decorator(func):
+        @mock.patch.object(DescribeContext, 'name', name)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+occurrence_state_data = {
+    'Occurrences': [
+        {
+            'Core': {
+                'Tier': {
+                    'Id': 'TierId[1]'
+                },
+                'Component': {
+                    'Id': 'ComponentId[1]'
+                },
+                'Name': 'CoreName[1]',
+                'Type': 'CoreType[1]'
+            },
+            'Configuration': {
+                'Solution': {
+                    'deployment:Unit': 'DeploymentUnit[1]'
+                },
+                'SettingNamespaces': [
+                    {
+                        'Key': 'SettingNamespace[1]'
+                    }
+                ]
+            },
+            'State': {
+                'Resources': {
+                    'Resource[1]': {
+                        'Id': 'ResourceId[1]',
+                        'Name': 'ResourceName[1]'
+                    }
+                },
+                'Attributes': {
+                    'ATTRIBUTE[1]': 'AttributeValue[1]'
+                }
+            }
+        },
+        {
+            'Core': {
+                'Tier': {
+                    'Id': 'TierId[2]'
+                },
+                'Component': {
+                    'Id': 'ComponentId[2]'
+                },
+                'Name': 'CoreName[2]',
+                'Type': 'CoreType[2]'
+            },
+            'Configuration': {
+                'Solution': {
+                    'deployment:Unit': 'DeploymentUnit[2]'
+                },
+                'SettingNamespaces': [
+                    {
+                        'Key': 'SettingNamespace[2]'
+                    }
+                ]
+            },
+            'State': {
+                'Resources': {
+                    'Resource[1]': {
+                        'Id': 'ResourceId[2]',
+                        'Name': 'ResourceName[2]'
+                    }
+                },
+                'Attributes': {
+                    'ATTRIBUTE[1]': 'AttributeValue[2]'
+                }
+            }
+        }
+    ]
+}
+
+
+@mock_backend(occurrence_state_data)
+def test_list_occurrences(blueprint_mock, ContextClassMock):
+    cli = CliRunner()
+    result = cli.invoke(
+        list_occurrences,
+        [
+            '--output-format', 'json'
+        ]
+    )
+    print(result.exception)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    print(result)
+    assert len(result) == 2
+    assert {
+        'TierId': 'TierId[1]',
+        'ComponentId': 'ComponentId[1]',
+        'Name': 'CoreName[1]',
+        'Type': 'CoreType[1]',
+    } in result
+    assert {
+        'TierId': 'TierId[2]',
+        'ComponentId': 'ComponentId[2]',
+        'Name': 'CoreName[2]',
+        'Type': 'CoreType[2]',
+    } in result
+
+
+@mock_describe_context('CoreName[1]')
+@mock_backend(occurrence_state_data)
+def test_describe_occurrence(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_occurrence,
+        [
+            '--name', 'CoreName[1]'
+        ]
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == occurrence_state_data['Occurrences'][0]
+
+
+@mock_describe_context('CoreName[1]')
+@mock_backend(occurrence_state_data)
+def test_describe_occurrence_query(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_occurrence,
+        [
+            '--name', 'CoreName[1]',
+            '--query', 'Configuration.Solution'
+        ]
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {'deployment:Unit': 'DeploymentUnit[1]'}
+
+
+@mock_describe_context('CoreName[1]')
+@mock_backend(occurrence_state_data)
+def test_describe_occurrence_query_solution(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_occurrence,
+        [
+            '--name', 'CoreName[1]',
+            'solution'
+        ]
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {'deployment:Unit': 'DeploymentUnit[1]'}
+
+
+@mock_describe_context('CoreName[1]')
+@mock_backend(occurrence_state_data)
+def test_describe_occurrence_query_resources(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_occurrence,
+        [
+            '--name', 'CoreName[1]',
+            'resources'
+        ]
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {'Resource[1]': {'Id': 'ResourceId[1]', 'Name': 'ResourceName[1]'}}
+
+
+@mock_describe_context('CoreName[1]')
+@mock_backend(occurrence_state_data)
+def test_describe_occurrence_query_setting_namespaces(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_occurrence,
+        [
+            '--name', 'CoreName[1]',
+            'setting-namespaces'
+        ]
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == [{'Key': 'SettingNamespace[1]'}]
+
+
+@mock_describe_context('CoreName[1]')
+@mock_backend(occurrence_state_data)
+def test_describe_occurrence_query_attributes(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_occurrence,
+        [
+            '--name', 'CoreName[1]',
+            'attributes',
+            '--output-format', 'json',
+        ]
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {'ATTRIBUTE[1]': 'AttributeValue[1]'}

--- a/hamlet-cli/tests/unit/command/component/test_occurrence.py
+++ b/hamlet-cli/tests/unit/command/component/test_occurrence.py
@@ -72,7 +72,8 @@ occurrence_state_data = {
                     'Id': 'TierId[1]'
                 },
                 'Component': {
-                    'Id': 'ComponentId[1]'
+                    'Id': 'ComponentId[1]',
+                    'RawId' : 'ComponentRawId[1]'
                 },
                 'Name': 'CoreName[1]',
                 'Type': 'CoreType[1]'
@@ -105,7 +106,8 @@ occurrence_state_data = {
                     'Id': 'TierId[2]'
                 },
                 'Component': {
-                    'Id': 'ComponentId[2]'
+                    'Id': 'ComponentId[2]',
+                    'RawId' : 'ComponentRawId[2]'
                 },
                 'Name': 'CoreName[2]',
                 'Type': 'CoreType[2]'
@@ -152,13 +154,13 @@ def test_list_occurrences(blueprint_mock, ContextClassMock):
     assert len(result) == 2
     assert {
         'TierId': 'TierId[1]',
-        'ComponentId': 'ComponentId[1]',
+        'ComponentId': 'ComponentRawId[1]',
         'Name': 'CoreName[1]',
         'Type': 'CoreType[1]',
     } in result
     assert {
         'TierId': 'TierId[2]',
-        'ComponentId': 'ComponentId[2]',
+        'ComponentId': 'ComponentRawId[2]',
         'Name': 'CoreName[2]',
         'Type': 'CoreType[2]',
     } in result


### PR DESCRIPTION
## Description

Uses the occurrence entrance from  to list and describe occurrences which are part of a hamlet district. The new commands belong to a new group called component which focuses on information about components 

- `hamlet component list-occurrences` shows all of the occurrences with their TierId, ComponentId, Name and Type available as outputs. The --query option on this parameter allows for filtering the output using JMESPath 
- `hamlet component describe-occurrence` provides the full occurrence output for a named occurrence. The Name field from the list occurrences command is used as the filter key. 
    - The --query option allows for filtering the output using JMESPath 
    - Subcommands `solution`, `attributes`, `resources`, `setting-namesspaces` are predefined JMESPath queries which can be used instead of the --query option to filter the output 

## Motivation and Context

Fixes #97 
Fixes #98 

The existing query command is essentially replaced by these new commands and aims to create a more specific query setup for occurrences. Since occurrences are such a core part to hamlet its important to be able to get information about these easily. 

Moving to the name attribute of the occurrence as the query key reduces the options required to describe a given occurrence and also simplifies the understanding required of an occurrence to find out what they are and their details. The query parameter requires the user to know about instances and versions which might not have been implemented as part of a solution. 

## How Has This Been Tested?

Tested locally and using test suite

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] Requires: https://github.com/hamlet-io/executor-bash/pull/174
- [x] Requires: https://github.com/hamlet-io/engine/pull/1578 

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
