### PR TITLE
refactor: find available bash install when calling

### DIFF
--- a/hamlet-cli/hamlet/backend/common/shell_vars_to_json.py
+++ b/hamlet-cli/hamlet/backend/common/shell_vars_to_json.py
@@ -1,18 +1,26 @@
 import os
 import json
+import shutil
 import subprocess
 
+from .exceptions import BackendException
 
 SHELL_SCRIPT_FILENAME = os.path.join(os.path.dirname(__file__), 'shell_vars_to_json.sh')
 
-
 def shell_vars_to_json(filename=None, vars_mapping=None):
+
+    if shutil.which('bash') is None:
+        raise BackendException(f'Could not find bash installation')
+
     args = [SHELL_SCRIPT_FILENAME, filename]
     for variable_name, variable_type in vars_mapping.items():
         args += [variable_name, variable_type]
     try:
         process = subprocess.Popen(
-            ['bash', *args],
+            [
+                shutil.which('bash'),
+                *args
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding='utf-8'

--- a/hamlet-cli/hamlet/backend/test/run.py
+++ b/hamlet-cli/hamlet/backend/test/run.py
@@ -1,6 +1,8 @@
 import subprocess
+import shutil
 from pytest import ExitCode as ec
 
+from hamlet.backend.common.exceptions import BackendException
 
 def run(
     testpaths=None,
@@ -9,6 +11,10 @@ def run(
 ):
     testpaths = testpaths or []
     # Do not use pytest.main because it can't correctly work with the files changed in runtime
+
+    if shutil.which('bash') is None:
+        raise BackendException(f'Could not find bash installation')
+
     try:
         args = [
             'pytest',
@@ -28,7 +34,7 @@ def run(
         stderr = subprocess.PIPE
         process = subprocess.Popen(
             [
-                '/bin/bash',
+                shutil.which('bash'),
                 '-c',
                 cmd
             ],

--- a/hamlet-cli/tests/conftest.py
+++ b/hamlet-cli/tests/conftest.py
@@ -16,6 +16,7 @@ class __CMDBContext:
         ROOT_DIR = os.getenv('TEST_ROOT_DIR')
     else:
         ROOT_DIR = os.getcwd() + '/.cmdb'
+        os.makedirs(ROOT_DIR, exist_ok=True)
 
     def create_cmdb_filename_compositor(self):
         root = self.dir


### PR DESCRIPTION
## Description

- When making call to bash from the cli ensure that we use an installed version using the equivalent of where for python
- Fixes an issue in testing where the cmdb root dir doesn't exist

## Motivation and Context

Ensures the cli works across different operating systems and installations

## How Has This Been Tested?

Tested locally and with test suite

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
