### PR TITLE
fix: skip refresh for orphaned deployments

### DIFF
--- a/hamlet-cli/hamlet/command/deploy/__init__.py
+++ b/hamlet-cli/hamlet/command/deploy/__init__.py
@@ -231,17 +231,17 @@ def run_deployments(
         if deployment_state == 'orphaned':
             click.echo((click.style(f'[-] deployment has been orphaned, running orphan clean up', bold=False, fg='yellow')))
 
-        click.echo('')
-
-        if refresh_outputs or deployment_state != 'orphaned' :
-            generate_args = {
-                **options.opts,
-                'entrance': 'deployment',
-                'deployment_group': deployment_group,
-                'deployment_unit': deployment_unit,
-                'output_dir': output_dir
-            }
-            create_template_backend.run(**generate_args, _is_cli=True)
+        click.echo(f'Deploymentstate {deployment_state}')
+        if refresh_outputs:
+            if deployment_state != 'orphaned':
+                generate_args = {
+                    **options.opts,
+                    'entrance': 'deployment',
+                    'deployment_group': deployment_group,
+                    'deployment_unit': deployment_unit,
+                    'output_dir': output_dir
+                }
+                create_template_backend.run(**generate_args, _is_cli=True)
 
         for operation in deployment['Operations']:
 

--- a/hamlet-cli/hamlet/command/deploy/__init__.py
+++ b/hamlet-cli/hamlet/command/deploy/__init__.py
@@ -231,7 +231,8 @@ def run_deployments(
         if deployment_state == 'orphaned':
             click.echo((click.style(f'[-] deployment has been orphaned, running orphan clean up', bold=False, fg='yellow')))
 
-        click.echo(f'Deploymentstate {deployment_state}')
+        click.echo('')
+
         if refresh_outputs:
             if deployment_state != 'orphaned':
                 generate_args = {


### PR DESCRIPTION

## Description

Fixes the logic to skip output generation on orphaned outputs

## Motivation and Context

We can't generate orphaned outputs as they don't exist in the cmdb anymore

## How Has This Been Tested?

tested locally 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
