### PR TITLE
feat: add relesae support for cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [ created ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install reqs
+      working-directory: ./hamlet-cli
+      run: pip install -r requirements/dev.txt
+
+    - name: Bump Minor Version
+      if: github.event_name == "push"
+      run: bump2version minor
+
+    - name: Bump Release Version
+      if: github.event_name == "release"
+      run: bump2version --new-version ${{ github.event.release.tag_name }} major
+
+    - name: Run Tests
+      working-directory: ./hamlet-cli
+      run: make tests
+
+    - name: Create Release
+      working-directory: ./hamlet-cli
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      working-directory: ./hamlet-cli
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: CI
+name: testing
 
 on: [push, pull_request]
 

--- a/hamlet-cli/requirements/dev.txt
+++ b/hamlet-cli/requirements/dev.txt
@@ -4,6 +4,7 @@ setuptools
 flake8
 
 ## packaging
+build
 wheel
 twine
 bump2version


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds automated support for releasing the cli to pypi 

## Motivation and Context

Releases the latest version of the hamlet cli to pypi on push and release tagging

## How Has This Been Tested?

Testing with PR

## Followup Actions

- [x] None
