### PR TITLE
fix: use pull release for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,11 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
         packages_dir: hamlet-cli/dist
 
-    - name: save version bump
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add .
-        git commit -m "chore: package release"
-        git push
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: "chore: release bump"
+        delete-branch: true
+        title: 'chore: update cli package version'
+        body: 'Updates the cli version details to align with pyi release'
+        labels: 'chore'


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Github actions can't push to protected branches, which is understandable. So instead we raise a PR against master 

## Motivation and Context

bump the version via PR to keep it aligned with whats in pypi 

## How Has This Been Tested?

Will test on merge

## Followup Actions

- [x] None
