### PR TITLE
Refactor prerelease master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,19 +28,17 @@ jobs:
         pip install -r requirements/dev.txt
         pip install -e ./
 
-    - name: Bump Minor Version
-      if: github.event_name == 'push'
+    - name: Create Pre-release build
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       working-directory: ./hamlet-cli
       run: |
-        new_version="$(bump2version --dry-run --list patch | grep new_version | sed -r s,"^.*=",,)"
-        echo "${new_version}"
-        bump2version --new-version "${new_version}" patch
+        bump2version build
 
     - name: Bump Release Version
-      if: github.event_name == 'release'
+      if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/')
       working-directory: ./hamlet-cli
       run: |
-        bump2version --new-version "${{ github.event.release.tag_name }}" major
+        bump2version --new-version "${{ github.event.release.tag_name }}" release
 
     - name: Run the compose network
       run: make run

--- a/hamlet-cli/.bumpversion.cfg
+++ b/hamlet-cli/.bumpversion.cfg
@@ -1,10 +1,16 @@
 [bumpversion]
-current_version = feat: bump version - {current_version} → {new_version}
-	feat: bump version - {current_version} → {new_version}
-	7.0.5
-commit = False
-tag = False
-message = feat: bump version - {current_version} → {new_version}
+current_version = 7.0.5
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
+serialize =
+    {major}.{minor}.{patch}-{release}{build}
+    {major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = prod
+first_value = dev
+values =
+    dev
+    prod
 
 [bumpversion:file:setup.py]
 

--- a/hamlet-cli/.bumpversion.cfg
+++ b/hamlet-cli/.bumpversion.cfg
@@ -1,16 +1,18 @@
 [bumpversion]
-current_version = 7.0.5
+current_version = 7.0.6-dev0
+commit = False
+tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize =
-    {major}.{minor}.{patch}-{release}{build}
-    {major}.{minor}.{patch}
+	{major}.{minor}.{patch}-{release}{build}
+	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
 values =
-    dev
-    prod
+	dev
+	prod
 
 [bumpversion:file:setup.py]
 

--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -24,7 +24,7 @@ class InstallCommand(install):
 
 setup(
     name='hamlet-cli',
-    version='7.0.5',
+    version='7.0.6-dev0',
     author='Hamlet',
     url="https://github.com/hamlet-io/executor-python",
     long_description=long_description,


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Adds a pre-release tagging strategy which will allow for building and publishing master commits as prereleases in pypi.
When a tag is applied to the repo then a normal package update will go through and make the release available in pypi 

## Motivation and Context

This is a cleaner strategy and allows us to have the latest docker image with the prerelease of the package and other docker releases can be aligned with the image that suits 


## How Has This Been Tested?

Will test with PR and deploy process

## Followup Actions

- [x] None
