### PR TITLE
fix: log engine fatal messages on failure

### DIFF
--- a/hamlet-cli/hamlet/backend/common/runner.py
+++ b/hamlet-cli/hamlet/backend/common/runner.py
@@ -75,13 +75,13 @@ def run(script_name, args, options, env, _is_cli):
                 script_call_line
             ],
             stdout=None if _is_cli else subprocess.PIPE,
-            stderr=None if _is_cli else subprocess.PIPE,
+            stderr=subprocess.STDOUT if _is_cli else subprocess.PIPE,
             encoding='utf-8',
             env=env_overrides
         )
-        process_result = process.communicate()
+        stdout, stderr = process.communicate()
         if not _is_cli and process.returncode != 0:
-            raise BackendException(process_result[1])
+            raise BackendException(stdout)
         if _is_cli and process.returncode != 0:
             raise BackendException(f'{script_name} failed to run')
     finally:

--- a/hamlet-cli/hamlet/command/deploy/list.py
+++ b/hamlet-cli/hamlet/command/deploy/list.py
@@ -1,10 +1,11 @@
 import os
 import re
 import click
+from tabulate import tabulate
 
 from hamlet.command.common import exceptions
 from hamlet.command.common.config import pass_options
-from hamlet.command.common.display import json_or_table_option
+from hamlet.command.common.display import json_or_table_option, wrap_text
 from hamlet.command.common.config import pass_options
 from .util import find_deployments_from_options
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- forwards logs when using cli mode to stdout and use this output to show exception details when the engine fails to run
- fixes missing imports for displaying the deployments list

## Motivation and Context

Quality of life changes to provide details of failures from the engine when the happen 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

