### PR TITLE
feat: add dryrun tasks to run deployment

### DIFF
--- a/hamlet-cli/hamlet/backend/manage/deployment/__init__.py
+++ b/hamlet-cli/hamlet/backend/manage/deployment/__init__.py
@@ -3,7 +3,6 @@ from hamlet.backend.common import runner
 
 def run(
     delete=None,
-    resource_group=None,
     deployment_initiate=None,
     deployment_group=None,
     deployment_monitor=None,
@@ -13,6 +12,7 @@ def run(
     deployment_wait=None,
     deployment_unit_subset=None,
     output_dir=None,
+    dryrun=None,
     log_level=None,
     root_dir=None,
     tenant=None,
@@ -25,7 +25,6 @@ def run(
 ):
     options = {
         '-d': delete,
-        '-g': resource_group,
         '-i': deployment_initiate,
         '-m': deployment_monitor,
         '-l': deployment_group,
@@ -33,8 +32,9 @@ def run(
         '-s': deployment_scope,
         '-u': deployment_unit,
         '-w': deployment_wait,
+        '-y': dryrun,
         '-z': deployment_unit_subset,
-        '-o': output_dir
+        '-o': output_dir,
     }
     env = {
         'GENERATION_LOG_LEVEL': log_level,

--- a/hamlet-cli/hamlet/command/deploy/create.py
+++ b/hamlet-cli/hamlet/command/deploy/create.py
@@ -38,7 +38,7 @@ from .util import find_deployments_from_options
     '-s',
     '--deployment-state',
     type=click.Choice(
-        ['deployed', 'notdeployed',],
+        ['deployed', 'notdeployed', ],
         case_sensitive=False,
     ),
     default=['deployed', 'notdeployed'],

--- a/hamlet-cli/hamlet/command/deploy/list.py
+++ b/hamlet-cli/hamlet/command/deploy/list.py
@@ -61,7 +61,7 @@ def deployments_table(data):
         ['deployed', 'notdeployed', 'orphaned', ],
         case_sensitive=False,
     ),
-    default=['deployed', 'notdeployed'],
+    default=['deployed', 'notdeployed', 'orphaned',],
     multiple=True,
     help='The states of deployments to include'
 )

--- a/hamlet-cli/tests/unit/command/deploy/test_deploy.py
+++ b/hamlet-cli/tests/unit/command/deploy/test_deploy.py
@@ -17,6 +17,7 @@ ALL_VALID_OPTIONS['-m,--deployment-mode'] = 'deployment_mode'
 ALL_VALID_OPTIONS['-s,--deployment-state'] = 'deployed'
 ALL_VALID_OPTIONS['--refresh-outputs'] = True
 ALL_VALID_OPTIONS['--confirm'] = True
+ALL_VALID_OPTIONS['--dryrun'] = True
 
 
 def template_backend_run_mock(data):


### PR DESCRIPTION


## Intent of Change
<!-- Delete all that do not apply                      -->
- Documentation (new or update to existing)
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Adds the ability to run a dry run before executing a deployment. This will submit the deployment to a providers service which will show the difference between the current deployment and the submitted deployment

Example for an AWS deployment
 
```bash 
hamlet --profile msw deploy run-deployments --dryrun --confirm -u instance
```

```bash
[*] solution/instance

(Info) Generating outputs:
[*] entrance: deployment | output: contract | subset: generationcontract

 Hamlet Engine Logs
--------------------

- warn - link occurrence not deployed - management-user-user1 -> management-sftp
- warn - link occurrence not deployed - management-user-user1 -> management-bucket

--------------------
[-] warn : 2
[-] Compact log output format used set GENERATION_LOG_FORMAT=full for the complete details

[*] entrance: deployment | output: resource
(Info)  - updating soln-instance-mswdev02-ap-southeast-2-template.json
(Info)  - updating soln-instance-mswdev02-ap-southeast-2-generation-contract.json
(Info) (Dryrun) Preparing the context...
(Info) (Dryrun) Check if the walksregister-integration-roleyfoley-soln-instance stack is already present...
(Info) (Dryrun) Update operation - submitting change set to determine update action...
(Info) (Dryrun) Results for walksregister-integration-roleyfoley-soln-instance
{
    "Changes": [
        {
            "Type": "Resource",
            "ResourceChange": {
                "Action": "Modify",
                "LogicalResourceId": "ec2InstanceXmgmtXinstanceXa",
                "PhysicalResourceId": "i-00064f4b2b6497a08",
                "ResourceType": "AWS::EC2::Instance",
                "Replacement": "Conditional",
                "Scope": [
                    "UpdatePolicy",
                    "Metadata",
                    "CreationPolicy",
                    "Properties"
                ],
                "Details": [
                    {
                        "Target": {
                            "Attribute": "Properties",
                            "Name": "InstanceType",
                            "RequiresRecreation": "Conditionally"
                        },
                        "Evaluation": "Static",
                        "ChangeSource": "DirectModification"
                    },
                    {
                        "Target": {
                            "Attribute": "Metadata",
                            "RequiresRecreation": "Never"
                        },
                        "Evaluation": "Static",
                        "ChangeSource": "DirectModification"
                    },
                    {
                        "Target": {
                            "Attribute": "UpdatePolicy",
                            "RequiresRecreation": "Never"
                        },
                        "Evaluation": "Static",
                        "ChangeSource": "DirectModification"
                    },
                    {
                        "Target": {
                            "Attribute": "CreationPolicy",
                            "RequiresRecreation": "Never"
                        },
                        "Evaluation": "Static",
                        "ChangeSource": "DirectModification"
                    }
                ]
            }
        }
    ],
    "ChangeSetName": "initial-1620010039",
    "StackName": "walksregister-integration-roleyfoley-soln-instance",
    "Parameters": [
        {
            "ParameterKey": "amiParamXec2InstanceXmgmtXinstanceXa",
            "ParameterValue": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
            "ResolvedValue": "ami-007b2c28096a63f37"
        }
    ]
}
(Info) (Dryrun) Update completed for walksregister-integration-roleyfoley-soln-instance
Start Deployment of solution/instance ? [y/N]: 
```

In this example I've run a deployment of an instance where I updated the instance type. The AWS cloudformation change set shows the updates that occur on the template. Combining this with the --confirm option on hamlet deploy run-deployments means I can see what could happen and choose what to do based on the change set report

- sets the default list deployments to include orphaned deployments to make them visible to users

## Motivation and Context

This allows for safety tests to be run before a deployment to confirm that updates are going to do what is expected. It does rely on what the cloud provider offers which can be confusing sometimes, but this is a good step in providing the info

Closes #121 
 
## How Has This Been Tested?

Tested locally and with test suite

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

