### PR TITLE
fix: run release versions based on created release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches:
       - master
-    tags:
-      - v*
   release:
-    types: [ published ]
-
+    types:
+      - created
+      - edited
 jobs:
   build:
 
@@ -29,13 +28,13 @@ jobs:
         pip install -e ./
 
     - name: Create Pre-release build
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
       working-directory: ./hamlet-cli
       run: |
         bump2version build
 
     - name: Bump Release Version
-      if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/')
+      if: github.event_name == 'release'
       working-directory: ./hamlet-cli
       run: |
         bump2version --new-version "${{ github.event.release.tag_name }}" release


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Uses Githubs event for a created release to trigger tag based releases.

## Motivation and Context

The current approach sees the master branch and bumps the version but doesn't trigger the release step when a tag is pushed 

## How Has This Been Tested?

Will be tested with this PR

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

