### PR TITLE
fix: bump release to next dev release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,12 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
         packages_dir: hamlet-cli/dist
 
+    - name: Bump to next dev release
+      if: startsWith(github.ref, 'refs/tags/' )
+      working-directory: ./hamlet-cli
+      run: |
+        bump2version minor --allow-dirty
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/hamlet-cli/.bumpversion.cfg
+++ b/hamlet-cli/.bumpversion.cfg
@@ -1,16 +1,16 @@
 [bumpversion]
-current_version = 8.1.1
+current_version = 8.2.0-dev0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -24,7 +24,7 @@ class InstallCommand(install):
 
 setup(
     name='hamlet-cli',
-    version='8.1.1',
+    version='8.2.0-dev0',
     author='Hamlet',
     url="https://github.com/hamlet-io/executor-python",
     long_description=long_description,


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

On tag releases bump to the next patch automatically to allow for continual pre-releases

## Motivation and Context

This allows for ongoing development between releases. The tag applied on a release will set the semver compliance but between development stages we reset to the next minor version

## How Has This Been Tested?

tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

