### PR TITLE
fix: include cookie cutter templates in package

### DIFF
--- a/hamlet-cli/MANIFEST.in
+++ b/hamlet-cli/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.md
 include setup-autocomplete.sh
 include hamlet/backend/test/templates/*.tmpl
+recursive-include hamlet/backend/generate/ *


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Fixes an issue where the generate cookie cutter templates weren't included in the python package

## Motivation and Context

Generate commands were failing when using the pip package

## How Has This Been Tested?

Tested locally outside of the edit pip install mode

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

