### PR TITLE
feat: engine management

### DIFF
--- a/hamlet-cli/hamlet/__init__.py
+++ b/hamlet-cli/hamlet/__init__.py
@@ -3,7 +3,7 @@
 import hamlet.command  # noqa
 import hamlet.command.generate  # noqa
 import hamlet.command.entrance  # noqa
-import hamlet.command.engine #noqa
+import hamlet.command.engine  # noqa
 import hamlet.command.test  # noqa
 import hamlet.command.manage  # noqa
 import hamlet.command.run  # noqa

--- a/hamlet-cli/hamlet/__init__.py
+++ b/hamlet-cli/hamlet/__init__.py
@@ -3,6 +3,7 @@
 import hamlet.command  # noqa
 import hamlet.command.generate  # noqa
 import hamlet.command.entrance  # noqa
+import hamlet.command.engine #noqa
 import hamlet.command.test  # noqa
 import hamlet.command.manage  # noqa
 import hamlet.command.run  # noqa

--- a/hamlet-cli/hamlet/backend/common/runner.py
+++ b/hamlet-cli/hamlet/backend/common/runner.py
@@ -52,22 +52,22 @@ def __env_params_to_envvars(env=None):
 
 def run(script_name, args, options, env, _is_cli):
 
+    env_overrides = { **global_env.ENGINE_ENV, **__env_params_to_envvars(env), **os.environ}
     try:
-        os.path.isdir(global_env.GENERATION_DIR)
+        os.path.isdir(env_overrides['GENERATION_DIR'])
     except TypeError:
-        raise BackendException(f'Could not find hamlet bash script dir at GENERATION_DIR: {global_env.GENERATION_DIR}')
+        raise BackendException(f'Could not find hamlet bash script dir at GENERATION_DIR: {env_overrides["GENERATION_DIR"]}')
 
     if shutil.which('bash') is None:
         raise BackendException('Could not find bash installation')
 
     try:
         script_call_line = __cli_params_to_script_call(
-            global_env.GENERATION_DIR,
+            env_overrides['GENERATION_DIR'],
             script_name,
             args=args,
             options=options
         )
-        env_overrides = {**__env_params_to_envvars(env), **os.environ}
         process = subprocess.Popen(
             [
                 shutil.which('bash'),

--- a/hamlet-cli/hamlet/backend/common/runner.py
+++ b/hamlet-cli/hamlet/backend/common/runner.py
@@ -52,11 +52,13 @@ def __env_params_to_envvars(env=None):
 
 def run(script_name, args, options, env, _is_cli):
 
-    env_overrides = { **global_env.ENGINE_ENV, **__env_params_to_envvars(env), **os.environ}
+    env_overrides = {**global_env.ENGINE_ENV, **__env_params_to_envvars(env), **os.environ}
     try:
         os.path.isdir(env_overrides['GENERATION_DIR'])
     except TypeError:
-        raise BackendException(f'Could not find hamlet bash script dir at GENERATION_DIR: {env_overrides["GENERATION_DIR"]}')
+        raise BackendException(
+            f'Could not find hamlet bash script dir at GENERATION_DIR: {env_overrides["GENERATION_DIR"]}'
+        )
 
     if shutil.which('bash') is None:
         raise BackendException('Could not find bash installation')

--- a/hamlet-cli/hamlet/backend/container_registry/__init__.py
+++ b/hamlet-cli/hamlet/backend/container_registry/__init__.py
@@ -1,0 +1,140 @@
+import os
+import base64
+import requests
+import tempfile
+import hashlib
+import shutil
+
+import www_authenticate
+
+from urllib import parse
+
+
+def get_registry_login_token(registry_url, repository, actions=['pull'], username=None, password=None, authorization_header=None):
+    '''
+    Uses the docker v2 registry api to get an auth token compliant with the registry
+    '''
+    registry_base_url = parse.urljoin(registry_url, 'v2/')
+    registry_version = requests.get(registry_base_url, allow_redirects=True)
+
+    if registry_version.status_code == requests.codes.ok:
+        return None
+
+    if registry_version.status_code != requests.codes.unauthorized:
+        raise requests.exceptions.HTTPError(registry_version)
+
+    if registry_version.status_code == requests.codes.unauthorized:
+
+        if username is not None and password is not None:
+            headers = {
+                'Authorization': 'Basic ' + base64.b64encode(f'{username}:{password}').decode('utf-8')
+            }
+
+        elif authorization_header is not None:
+            headers = {
+                'Authorization' : authorization_header
+            }
+        else:
+            headers = {}
+
+        status_respose = www_authenticate.parse(registry_version.headers['WWW-Authenticate'])
+
+        if 'bearer' in status_respose:
+            bearer_info = status_respose['bearer']
+            if actions:
+                scope = f'repository:{repository}:' + ','.join(actions)
+            elif 'scope' in bearer_info:
+                scope = bearer_info['scope']
+            else:
+                scope = ''
+            url_parts = list(parse.urlparse(bearer_info['realm']))
+            query = parse.parse_qs(url_parts[4])
+            query.update({
+                'service': bearer_info['service'],
+                'scope': scope
+            })
+            url_parts[4] = parse.urlencode(query, True)
+            url_parts[0] = 'https'
+            auth_url = parse.urlunparse(url_parts)
+
+            auth_response = requests.get(auth_url, headers=headers)
+            auth_response.raise_for_status()
+
+            auth_json = auth_response.json()
+
+            return auth_json.get('access_token') or auth_json['token']
+
+    return None
+
+
+def get_registry_image_manifest(registry_url, repository, tag, auth_token):
+    '''
+    Get the manifest of a docker image based on the v2 docker registry spec
+    The manifest contains the layers and details of the over all docker image
+    '''
+    manifest_url = parse.urljoin(registry_url, f'v2/{repository}/manifests/{tag}')
+    if auth_token is not None:
+        headers = {
+            'Authorization' : f'Bearer {auth_token}',
+            'Accept': 'application/vnd.docker.distribution.manifest.v2+json'
+        }
+    else:
+        headers = {}
+
+    manifest_response = requests.get(manifest_url, headers=headers, allow_redirects=True)
+    manifest_response.raise_for_status()
+
+    return manifest_response.json()
+
+
+def pull_registry_image_to_dir(registry_url, repository, manifest, auth_token, dest_dir):
+    '''
+    Pull down all of the layers from a manifest extract the tars over the top of each other
+    This is what docker itself does we are just using the docker images as file sharing rather than an container
+    '''
+    blob_base_url = parse.urljoin(registry_url, f'/v2/{repository}/blobs/')
+    if auth_token is not None:
+        headers = {
+            'Authorization' : f'Bearer {auth_token}'
+        }
+    else:
+        headers = {}
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        extract_dir = os.path.join(temp_dir, 'extract')
+        os.makedirs(extract_dir)
+
+        for layer in manifest['layers']:
+            with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as layer_file:
+                layer_url = blob_base_url + layer['digest']
+
+                layer_response = requests.get(layer_url, headers=headers, allow_redirects=True)
+                layer_response.raise_for_status()
+                layer_content = requests.get(layer_response.url, stream=True, headers=headers)
+                layer_content.raise_for_status()
+
+                for chunk in layer_content.iter_content(chunk_size=( 1024 * 1024)):
+                    if chunk:
+                        layer_file.write(chunk)
+
+                layer_file.flush()
+
+                digest_algorithm = layer['digest'].split(':')[0]
+                digest_hash = layer['digest'].split(':')[1]
+
+                file_hash = hashlib.new(digest_algorithm)
+                with open(layer_file.name,"rb") as f:
+                    for byte_block in iter(lambda: f.read(( 1024 * 1024)),b""):
+                        file_hash.update(byte_block)
+
+                if digest_hash != file_hash.hexdigest():
+                    print(f'Layer hash does not match digest - ours {file_hash.hexdigest()} - theirs {digest_hash}')
+
+                if layer['mediaType'] == 'application/vnd.docker.image.rootfs.diff.tar.gzip':
+
+                    shutil.unpack_archive(layer_file.name, extract_dir, 'gztar')
+
+        if os.listdir(extract_dir):
+            if os.path.isdir(dest_dir):
+                shutil.rmtree(dest_dir)
+            shutil.copytree(extract_dir, dest_dir, symlinks=True)

--- a/hamlet-cli/hamlet/backend/container_registry/__init__.py
+++ b/hamlet-cli/hamlet/backend/container_registry/__init__.py
@@ -10,7 +10,13 @@ import www_authenticate
 from urllib import parse
 
 
-def get_registry_login_token(registry_url, repository, actions=['pull'], username=None, password=None, authorization_header=None):
+def get_registry_login_token(
+        registry_url,
+        repository, actions=['pull'],
+        username=None,
+        password=None,
+        authorization_header=None
+):
     '''
     Uses the docker v2 registry api to get an auth token compliant with the registry
     '''
@@ -32,7 +38,7 @@ def get_registry_login_token(registry_url, repository, actions=['pull'], usernam
 
         elif authorization_header is not None:
             headers = {
-                'Authorization' : authorization_header
+                'Authorization': authorization_header
             }
         else:
             headers = {}
@@ -75,7 +81,7 @@ def get_registry_image_manifest(registry_url, repository, tag, auth_token):
     manifest_url = parse.urljoin(registry_url, f'v2/{repository}/manifests/{tag}')
     if auth_token is not None:
         headers = {
-            'Authorization' : f'Bearer {auth_token}',
+            'Authorization': f'Bearer {auth_token}',
             'Accept': 'application/vnd.docker.distribution.manifest.v2+json'
         }
     else:
@@ -95,7 +101,7 @@ def pull_registry_image_to_dir(registry_url, repository, manifest, auth_token, d
     blob_base_url = parse.urljoin(registry_url, f'/v2/{repository}/blobs/')
     if auth_token is not None:
         headers = {
-            'Authorization' : f'Bearer {auth_token}'
+            'Authorization': f'Bearer {auth_token}'
         }
     else:
         headers = {}
@@ -113,7 +119,7 @@ def pull_registry_image_to_dir(registry_url, repository, manifest, auth_token, d
                 layer_content = requests.get(layer_response.url, stream=True, headers=headers)
                 layer_content.raise_for_status()
 
-                for chunk in layer_content.iter_content(chunk_size=( 1024 * 1024)):
+                for chunk in layer_content.iter_content(chunk_size=(1024 * 1024)):
                     if chunk:
                         layer_file.write(chunk)
 
@@ -123,8 +129,8 @@ def pull_registry_image_to_dir(registry_url, repository, manifest, auth_token, d
                 digest_hash = layer['digest'].split(':')[1]
 
                 file_hash = hashlib.new(digest_algorithm)
-                with open(layer_file.name,"rb") as f:
-                    for byte_block in iter(lambda: f.read(( 1024 * 1024)),b""):
+                with open(layer_file.name, "rb") as f:
+                    for byte_block in iter(lambda: f.read((1024 * 1024)), b""):
                         file_hash.update(byte_block)
 
                 if digest_hash != file_hash.hexdigest():

--- a/hamlet-cli/hamlet/backend/container_registry/__init__.py
+++ b/hamlet-cli/hamlet/backend/container_registry/__init__.py
@@ -95,7 +95,7 @@ def get_registry_image_manifest(registry_url, repository, tag, auth_token):
 
 def pull_registry_image_to_dir(registry_url, repository, manifest, auth_token, dest_dir):
     '''
-    Pull down all of the layers from a manifest extract the tars over the top of each other
+    Pull down all of the layers from a manifest and extract the tars over the top of each other
     This is what docker itself does we are just using the docker images as file sharing rather than an container
     '''
     blob_base_url = parse.urljoin(registry_url, f'/v2/{repository}/blobs/')

--- a/hamlet-cli/hamlet/backend/create/template/__init__.py
+++ b/hamlet-cli/hamlet/backend/create/template/__init__.py
@@ -23,7 +23,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     options = {
         '-e': entrance,

--- a/hamlet-cli/hamlet/backend/engine/__init__.py
+++ b/hamlet-cli/hamlet/backend/engine/__init__.py
@@ -52,10 +52,9 @@ class EngineStore():
         self._global_engine = engine.name
 
         self.store_state = {
-            'global_engine' : self.global_engine
+            'global_engine': self.global_engine
         }
         self.save_store_state()
-
 
     def get_engine(self, name, allow_missing=False):
         '''
@@ -76,7 +75,6 @@ class EngineStore():
         for loader in self.engine_loaders:
             for engine in loader.engines:
                 self._engines[engine.name] = engine
-
 
     def load_store_state(self):
         if os.path.isfile(self.store_state_file):

--- a/hamlet-cli/hamlet/backend/engine/__init__.py
+++ b/hamlet-cli/hamlet/backend/engine/__init__.py
@@ -3,37 +3,56 @@ import json
 
 from hamlet.backend.common.exceptions import BackendException
 
-from .common import ENGINE_STORE_DIR
+from .common import ENGINE_STORE_DEFAULT_DIR
 from .engine_loader import GlobalEngineLoader, InstalledEngineLoader, UnicycleEngineLoader
 
 
 class EngineStore():
-    def __init__(self):
+    '''
+    The EngineStore manages the collection of engines that can be used for hamlet
+    Loaders are assigned to the engine store which provide engines to the store
+    It manages the location of the engine installations and maintains a persistant state
+    that tracks global properties that effect all engines
+    '''
+    def __init__(self, store_dir):
         self._engines = {}
-        self.store_state_file = os.path.join(ENGINE_STORE_DIR, 'store_state.json')
+        self.store_dir = store_dir
+        self._store_state_file = os.path.join(self.store_dir, 'store_state.json')
+        self.engine_dir = os.path.join(self.store_dir, 'engines')
 
         self.store_state = None
         self.load_store_state()
 
         self._global_engine = self.store_state.get('global_engine', None) if self.store_state is not None else None
 
-    engine_loaders = [
-        InstalledEngineLoader(),
-        GlobalEngineLoader(),
-        UnicycleEngineLoader(),
-    ]
+        self.engine_loaders = [
+            InstalledEngineLoader(engine_dir=self.engine_dir),
+            GlobalEngineLoader(),
+            UnicycleEngineLoader(),
+        ]
 
     @property
     def engines(self):
+        '''
+        Return the engines that have been loaded into the store
+        '''
         self._load_engines()
         return list(filter(lambda x: not x.hidden, self._engines.values()))
 
     @property
     def global_engine(self):
+        '''
+        The global engine defines a special engine that uses other engines to provide parts
+        the global provides a consistent location that will link to other engine installations
+        '''
         return self._global_engine
 
     @global_engine.setter
     def global_engine(self, name):
+        '''
+        Setting the global engine will locate the provided engine then update
+        its symlinks to point to the provided engine.
+        '''
         global_engine = self.get_engine('_global')
         engine = self.get_engine(name)
 
@@ -56,9 +75,18 @@ class EngineStore():
         }
         self.save_store_state()
 
+    def _load_engines(self):
+        '''
+        Get the engines from the loaders
+        '''
+        for loader in self.engine_loaders:
+            for engine in loader.load():
+                engine.engine_dir = self.engine_dir
+                self._engines[engine.name] = engine
+
     def get_engine(self, name, allow_missing=False):
         '''
-        returns engines matching the name and version provided
+        returns engines matching the name provided
         '''
         self._load_engines()
         result = self._engines.get(name, None)
@@ -68,26 +96,24 @@ class EngineStore():
 
         return result
 
-    def _load_engines(self):
-        '''
-        Get the engines from the loaders
-        '''
-        for loader in self.engine_loaders:
-            for engine in loader.engines:
-                self._engines[engine.name] = engine
-
     def load_store_state(self):
-        if os.path.isfile(self.store_state_file):
-            with open(self.store_state_file, 'r') as file:
+        '''
+        Load the persisted enginestore state
+        '''
+        if os.path.isfile(self._store_state_file):
+            with open(self._store_state_file, 'r') as file:
                 self.store_state = json.load(file)
 
     def save_store_state(self):
+        '''
+        Save the persisted enginestore state
+        '''
         if self.store_state is not None:
-            if not os.path.isdir(ENGINE_STORE_DIR):
-                os.makedirs(ENGINE_STORE_DIR)
+            if not os.path.isdir(self.store_dir):
+                os.makedirs(self.store_dir)
 
-            with open(self.store_state_file, 'w') as file:
+            with open(self._store_state_file, 'w') as file:
                 json.dump(self.store_state, file)
 
 
-engine_store = EngineStore()
+engine_store = EngineStore(store_dir=ENGINE_STORE_DEFAULT_DIR)

--- a/hamlet-cli/hamlet/backend/engine/__init__.py
+++ b/hamlet-cli/hamlet/backend/engine/__init__.py
@@ -1,0 +1,95 @@
+import os
+import json
+
+from hamlet.backend.common.exceptions import BackendException
+
+from .common import ENGINE_STORE_DIR
+from .engine_loader import GlobalEngineLoader, InstalledEngineLoader, UnicycleEngineLoader
+
+
+class EngineStore():
+    def __init__(self):
+        self._engines = {}
+        self.store_state_file = os.path.join(ENGINE_STORE_DIR, 'store_state.json')
+
+        self.store_state = None
+        self.load_store_state()
+
+        self._global_engine = self.store_state.get('global_engine', None) if self.store_state is not None else None
+
+    engine_loaders = [
+        InstalledEngineLoader(),
+        GlobalEngineLoader(),
+        UnicycleEngineLoader(),
+    ]
+
+    @property
+    def engines(self):
+        self._load_engines()
+        return list(filter(lambda x: not x.hidden, self._engines.values()))
+
+    @property
+    def global_engine(self):
+        return self._global_engine
+
+    @global_engine.setter
+    def global_engine(self, name):
+        global_engine = self.get_engine('_global')
+        engine = self.get_engine(name)
+
+        for type, path in global_engine.part_paths.items():
+            if os.path.islink(path):
+                os.unlink(path)
+
+            if os.path.isdir(path):
+                os.rmdir(path)
+
+            if engine.part_paths.get(type, None) is not None:
+                os.symlink(engine.part_paths[type], path, target_is_directory=True)
+            else:
+                os.makedirs(path)
+
+        self._global_engine = engine.name
+
+        self.store_state = {
+            'global_engine' : self.global_engine
+        }
+        self.save_store_state()
+
+
+    def get_engine(self, name, allow_missing=False):
+        '''
+        returns engines matching the name and version provided
+        '''
+        self._load_engines()
+        result = self._engines.get(name, None)
+
+        if not allow_missing and result is None:
+            raise BackendException(f'Could not find engine {name} in engine store')
+
+        return result
+
+    def _load_engines(self):
+        '''
+        Get the engines from the loaders
+        '''
+        for loader in self.engine_loaders:
+            for engine in loader.engines:
+                self._engines[engine.name] = engine
+
+
+    def load_store_state(self):
+        if os.path.isfile(self.store_state_file):
+            with open(self.store_state_file, 'r') as file:
+                self.store_state = json.load(file)
+
+    def save_store_state(self):
+        if self.store_state is not None:
+            if not os.path.isdir(ENGINE_STORE_DIR):
+                os.makedirs(ENGINE_STORE_DIR)
+
+            with open(self.store_state_file, 'w') as file:
+                json.dump(self.store_state, file)
+
+
+engine_store = EngineStore()

--- a/hamlet-cli/hamlet/backend/engine/common.py
+++ b/hamlet-cli/hamlet/backend/engine/common.py
@@ -1,0 +1,8 @@
+import os
+
+from hamlet.env import HAMLET_HOME_DIR
+
+ENGINE_STORE_DIR = os.path.join(HAMLET_HOME_DIR, 'engine')
+ENGINE_STORE_ENGINES_DIR = os.path.join(ENGINE_STORE_DIR, 'engines')
+ENGINE_STORE_ENGINE_STATE_FILENAME = 'engine_state.json'
+ENGINE_GLOBAL_NAME = '_global'

--- a/hamlet-cli/hamlet/backend/engine/common.py
+++ b/hamlet-cli/hamlet/backend/engine/common.py
@@ -2,8 +2,7 @@ import os
 
 from hamlet.env import HAMLET_HOME_DIR
 
-ENGINE_STORE_DIR = os.path.join(HAMLET_HOME_DIR, 'engine')
-ENGINE_STORE_ENGINES_DIR = os.path.join(ENGINE_STORE_DIR, 'engines')
-ENGINE_STORE_ENGINE_STATE_FILENAME = 'engine_state.json'
+ENGINE_STORE_DEFAULT_DIR = os.path.join(HAMLET_HOME_DIR, 'engine')
 ENGINE_GLOBAL_NAME = '_global'
 ENGINE_DEFAULT_GLOBAL_ENGINE = 'unicycle'
+ENGINE_STATE_FILE_NAME = 'engine_state.json'

--- a/hamlet-cli/hamlet/backend/engine/common.py
+++ b/hamlet-cli/hamlet/backend/engine/common.py
@@ -6,3 +6,4 @@ ENGINE_STORE_DIR = os.path.join(HAMLET_HOME_DIR, 'engine')
 ENGINE_STORE_ENGINES_DIR = os.path.join(ENGINE_STORE_DIR, 'engines')
 ENGINE_STORE_ENGINE_STATE_FILENAME = 'engine_state.json'
 ENGINE_GLOBAL_NAME = '_global'
+ENGINE_DEFAULT_GLOBAL_ENGINE = 'unicycle'

--- a/hamlet-cli/hamlet/backend/engine/engine.py
+++ b/hamlet-cli/hamlet/backend/engine/engine.py
@@ -1,0 +1,235 @@
+import os
+import json
+import shutil
+import hashlib
+from abc import ABC, abstractmethod, abstractproperty
+from sys import path
+
+from hamlet.backend.common.exceptions import BackendException
+from .common import ENGINE_STORE_ENGINES_DIR, ENGINE_STORE_ENGINE_STATE_FILENAME
+
+from .engine_part import EnginePartInterface
+from .engine_source import EngineSourceInterface
+
+
+class EngineInterface(ABC):
+    def __init__(self, name, description, hidden=False):
+        self.name = name
+        self.description = description
+        self.hidden = hidden
+        self.digest = ''
+
+        self.install_path = os.path.join(ENGINE_STORE_ENGINES_DIR, self.name)
+        self.install_state_file = os.path.join(self.install_path, ENGINE_STORE_ENGINE_STATE_FILENAME)
+
+        self.install_state = None
+        self.load_install_state()
+
+        self._parts = {}
+        self._sources = {}
+
+    _environment = {
+        'GENERATION_ENGINE_DIR' : [
+            {
+                'part_type' :  'core-engine',
+                'env_path' : ''
+            }
+        ],
+        'GENERATION_PLUGIN_DIRS' : [
+            {
+                'part_type' :  'engine-plugin-aws',
+                'env_path' : ''
+            },
+            {
+                'part_type' :  'engine-plugin-azure',
+                'env_path' : ''
+            }
+        ],
+        'GENERATION_BIN_DIR' : [
+            {
+                'part_type' :  'engine-binary',
+                'env_path' : ''
+            }
+        ],
+        'GENERATION_BASE_DIR'   : [
+            {
+                'part_type' :  'executor-bash',
+                'env_path' : ''
+            }
+        ],
+        'GENERATION_DIR' : [
+            {
+                'part_type' :  'executor-bash',
+                'env_path' : 'cli'
+            }
+        ],
+        'AUTOMATION_DIR' : [
+            {
+                'part_type' :  'executor-bash',
+                'env_path' : 'automation/jenkins/aws'
+            }
+        ],
+        'AUTOMATION_BASE_DIR'  : [
+            {
+                'part_type' :  'executor-bash',
+                'env_path' : 'automation'
+            }
+        ],
+    }
+
+    @property
+    def installed(self):
+        return True if self.install_state is not None else False
+
+    @property
+    def parts(self):
+        return self._parts.values()
+
+    @parts.setter
+    def parts(self, parts):
+        for part in parts:
+            if isinstance(part, EnginePartInterface):
+                self._parts[part.type] = part
+            else:
+                raise ValueError('part is not an EnginePart')
+
+    @parts.deleter
+    def parts(self, type):
+        try:
+            del self._parts[type]
+        except KeyError:
+            raise BackendException(f'part {type} not found')
+
+    @property
+    def sources(self):
+        return self._sources.values()
+
+    @sources.setter
+    def sources(self, sources):
+        for source in sources:
+            if isinstance(source, EngineSourceInterface):
+                self._sources[source.name] = source
+            else:
+                raise ValueError('source is not an EngineSource')
+
+    @sources.deleter
+    def sources(self, source_name):
+        try:
+            del self._sources[source_name]
+        except KeyError:
+            raise BackendException(f'source {source_name} not found')
+
+    @property
+    def part_paths(self):
+        return self.install_state.get('part_paths', None)
+
+    @property
+    def environment(self):
+        env_result = {}
+        if self.part_paths is not None:
+            for k, part_mappings in self._environment.items():
+                env_values = []
+                for part_mapping in part_mappings:
+                    if self.part_paths.get(part_mapping['part_type'], None) is not None:
+                        env_values.append(
+                            os.path.dirname(
+                                os.path.join(
+                                    self.part_paths[part_mapping['part_type']],
+                                    part_mapping["env_path"]
+                                ) + '/'
+                            )
+                        )
+                env_result[k] = ';'.join(env_values)
+        return env_result
+
+    def _get_source(self, source_name):
+        source = None
+        try:
+            source = self._sources[source_name]
+        except KeyError:
+            raise  BackendException(f'source {source_name} not found in engine')
+
+        return source
+
+    def _get_engine_source_dir(self, source_name):
+        source = self._get_source(source_name)
+        return os.path.join(self.install_path, source.name )
+
+    def load_install_state(self):
+        if os.path.isfile(self.install_state_file):
+            with open(self.install_state_file, 'r') as file:
+                self.install_state = json.load(file)
+
+    def save_install_state(self):
+        if not os.path.isdir(self.install_path):
+            os.makedirs(self.install_path)
+
+        with open(self.install_state_file, 'w') as file:
+            json.dump(self.install_state, file)
+
+    def _set_part_paths(self):
+        part_paths = {}
+        for part in self.parts:
+            part_paths[part.type] = os.path.join(
+                self._get_engine_source_dir(part.source_name),
+                part.source_path
+            )
+        return part_paths
+
+    @abstractmethod
+    def install(self):
+        raise NotImplementedError
+
+
+class InstalledEngine(EngineInterface):
+    def __init__(self, name, description, hidden, digest):
+        super().__init__(name, description, hidden=hidden)
+        self.digest = digest
+
+    def install():
+        pass
+
+
+class GlobalEngine(EngineInterface):
+
+    def install(self):
+
+        for source in self.sources:
+            source_dir = self._get_engine_source_dir(source.name)
+            source.pull(source_dir)
+
+        self.install_state = {
+            'name' : self.name,
+            'description' : self.description,
+            'hidden' : self.hidden,
+            'digest' : self.digest,
+            'part_paths' : self._set_part_paths(),
+            'source_digests' : {}
+        }
+        self.save_install_state()
+
+
+class Engine(EngineInterface):
+
+    def install(self):
+
+        if os.path.isdir(self.install_path):
+            shutil.rmtree(self.install_path)
+
+        source_digests = {}
+        for source in self.sources:
+            source_dir = self._get_engine_source_dir(source.name)
+            source.pull(source_dir)
+            source_digests[source.name] = source.digest
+
+        self.digest = 'sha256:' + hashlib.sha256(':'.join(source_digests.values()).encode('utf-8')).hexdigest()
+
+        self.install_state = {
+            'name' : self.name,
+            'description' : self.description,
+            'hidden' : self.hidden,
+            'digest' : self.digest,
+            'part_paths' : self._set_part_paths(),
+            'source_digests' : source_digests
+        }
+        self.save_install_state()

--- a/hamlet-cli/hamlet/backend/engine/engine.py
+++ b/hamlet-cli/hamlet/backend/engine/engine.py
@@ -5,10 +5,10 @@ import hashlib
 from abc import ABC, abstractmethod
 
 from hamlet.backend.common.exceptions import BackendException
-from .common import ENGINE_STORE_ENGINES_DIR, ENGINE_STORE_ENGINE_STATE_FILENAME
 
 from .engine_part import EnginePartInterface
 from .engine_source import EngineSourceInterface
+from .common import ENGINE_STATE_FILE_NAME
 
 
 class EngineInterface(ABC):
@@ -16,13 +16,15 @@ class EngineInterface(ABC):
         self.name = name
         self.description = description
         self.hidden = hidden
-        self.digest = ''
 
-        self.install_path = os.path.join(ENGINE_STORE_ENGINES_DIR, self.name)
-        self.install_state_file = os.path.join(self.install_path, ENGINE_STORE_ENGINE_STATE_FILENAME)
+        self.engine_state_filename = ENGINE_STATE_FILE_NAME
 
-        self.install_state = None
-        self.load_install_state()
+        self._engine_dir = None
+        self._install_state = {
+            'name': self.name,
+            'description': self.description,
+            'hidden': self.hidden
+        }
 
         self._parts = {}
         self._sources = {}
@@ -78,10 +80,69 @@ class EngineInterface(ABC):
 
     @property
     def installed(self):
-        return True if self.install_state is not None else False
+        '''
+        Check to see if the engine has been installed locally
+        '''
+        return True if self.digest is not None else False
+
+    @property
+    def engine_dir(self):
+        '''
+        The engine dir defines the base folder where engines are kept
+        '''
+        return self._engine_dir
+
+    @engine_dir.setter
+    def engine_dir(self, engine_dir):
+        '''
+        The engine dir is set as part of the loader process
+        '''
+        self._engine_dir = engine_dir
+        self._load_install_state()
+
+    @property
+    def install_path(self):
+        '''
+        The install path is where the components of the engine will be installed
+        '''
+        return os.path.join(self.engine_dir, self.name)
+
+    @property
+    def install_state_file(self):
+        '''
+        The install state file is a persistant file that holds the install_state
+        '''
+        return os.path.join(self.install_path, self.engine_state_filename)
+
+    @property
+    def install_state(self):
+        '''
+        The install state contains the details about the instaltion
+        '''
+        self._load_install_state()
+        return self._install_state
+
+    def update_install_state(self):
+        '''
+        Builds the internal state and saves it to the persistant store
+        '''
+        self._install_state['part_paths'] = self._get_part_paths()
+        self._install_state['source_digests'] = self._get_source_digests()
+        self._install_state['digest'] = self._format_engine_digest(self._install_state['source_digests'].values())
+        self._save_install_state()
+
+    @property
+    def digest(self):
+        '''
+        returns the digests of the current installed sources
+        '''
+        return self.install_state.get('digest', None)
 
     @property
     def parts(self):
+        '''
+        Parts link concrete hamlet components to sources
+        '''
         return self._parts.values()
 
     @parts.setter
@@ -101,6 +162,9 @@ class EngineInterface(ABC):
 
     @property
     def sources(self):
+        '''
+        A source defines an external location which implements engine part(s)
+        '''
         return self._sources.values()
 
     @sources.setter
@@ -120,11 +184,19 @@ class EngineInterface(ABC):
 
     @property
     def part_paths(self):
+        '''
+        Part paths list the physical location of an installed part for a given engine
+        '''
         return self.install_state.get('part_paths', None)
 
     @property
     def environment(self):
+        '''
+        Using the part parts generate a dict of hamlet environment variables that are used
+        to determine where different engine parts are by the executor
+        '''
         env_result = {}
+        self._load_install_state()
         if self.part_paths is not None:
             for k, part_mappings in self._environment.items():
                 env_values = []
@@ -142,6 +214,9 @@ class EngineInterface(ABC):
         return env_result
 
     def _get_source(self, source_name):
+        '''
+        Get a particular source
+        '''
         source = None
         try:
             source = self._sources[source_name]
@@ -151,22 +226,31 @@ class EngineInterface(ABC):
         return source
 
     def _get_engine_source_dir(self, source_name):
+        '''
+        Find the location of a source for within an instllation
+        '''
         source = self._get_source(source_name)
         return os.path.join(self.install_path, source.name)
 
-    def load_install_state(self):
+    def _load_install_state(self):
+        '''
+        Load the state of an engine based on its install path
+        '''
         if os.path.isfile(self.install_state_file):
             with open(self.install_state_file, 'r') as file:
-                self.install_state = json.load(file)
+                self._install_state = json.load(file)
 
-    def save_install_state(self):
+    def _save_install_state(self):
+        '''
+        Writes the installation state to disk so that it can be accessed between cli runs
+        '''
         if not os.path.isdir(self.install_path):
             os.makedirs(self.install_path)
 
         with open(self.install_state_file, 'w') as file:
-            json.dump(self.install_state, file)
+            json.dump(self._install_state, file)
 
-    def _set_part_paths(self):
+    def _get_part_paths(self):
         part_paths = {}
         for part in self.parts:
             part_paths[part.type] = os.path.join(
@@ -175,18 +259,40 @@ class EngineInterface(ABC):
             )
         return part_paths
 
+    def _get_source_digests(self):
+        '''
+        Each source creates a digest that we use to determine updates
+        of the overall engine
+        '''
+        source_digests = {}
+        for source in self.sources:
+            source_digests[source.name] = source.digest
+
+        return source_digests
+
+    def _format_engine_digest(self, source_digests):
+        return 'sha256:' + hashlib.sha256(':'.join(source_digests).encode('utf-8')).hexdigest()
+
     @abstractmethod
     def install(self):
-        raise NotImplementedError
+        '''
+        The install method should loop through all sources and run their pull() method
+        Once this has been completed the function should run self.update_install_state()
+        This will collect the current state once the install has been completed
+        '''
+        pass
 
 
 class InstalledEngine(EngineInterface):
-    def __init__(self, name, description, hidden, digest):
+    def __init__(self, name, description, digest, hidden):
         super().__init__(name, description, hidden=hidden)
-        self.digest = digest
+        self._installed_digest = digest
 
-    def install():
-        pass
+    def digest(self):
+        return self._installed_digest
+
+    def install(self):
+        self.update_install_state()
 
 
 class GlobalEngine(EngineInterface):
@@ -196,16 +302,7 @@ class GlobalEngine(EngineInterface):
         for source in self.sources:
             source_dir = self._get_engine_source_dir(source.name)
             source.pull(source_dir)
-
-        self.install_state = {
-            'name': self.name,
-            'description': self.description,
-            'hidden': self.hidden,
-            'digest': self.digest,
-            'part_paths': self._set_part_paths(),
-            'source_digests': {},
-        }
-        self.save_install_state()
+        self.update_install_state()
 
 
 class Engine(EngineInterface):
@@ -215,20 +312,8 @@ class Engine(EngineInterface):
         if os.path.isdir(self.install_path):
             shutil.rmtree(self.install_path)
 
-        source_digests = {}
         for source in self.sources:
             source_dir = self._get_engine_source_dir(source.name)
             source.pull(source_dir)
-            source_digests[source.name] = source.digest
 
-        self.digest = 'sha256:' + hashlib.sha256(':'.join(source_digests.values()).encode('utf-8')).hexdigest()
-
-        self.install_state = {
-            'name': self.name,
-            'description': self.description,
-            'hidden': self.hidden,
-            'digest': self.digest,
-            'part_paths': self._set_part_paths(),
-            'source_digests': source_digests,
-        }
-        self.save_install_state()
+        self.update_install_state()

--- a/hamlet-cli/hamlet/backend/engine/engine.py
+++ b/hamlet-cli/hamlet/backend/engine/engine.py
@@ -2,8 +2,7 @@ import os
 import json
 import shutil
 import hashlib
-from abc import ABC, abstractmethod, abstractproperty
-from sys import path
+from abc import ABC, abstractmethod
 
 from hamlet.backend.common.exceptions import BackendException
 from .common import ENGINE_STORE_ENGINES_DIR, ENGINE_STORE_ENGINE_STATE_FILENAME
@@ -29,50 +28,50 @@ class EngineInterface(ABC):
         self._sources = {}
 
     _environment = {
-        'GENERATION_ENGINE_DIR' : [
+        'GENERATION_ENGINE_DIR': [
             {
-                'part_type' :  'core-engine',
-                'env_path' : ''
+                'part_type': 'core-engine',
+                'env_path': ''
             }
         ],
-        'GENERATION_PLUGIN_DIRS' : [
+        'GENERATION_PLUGIN_DIRS': [
             {
-                'part_type' :  'engine-plugin-aws',
-                'env_path' : ''
+                'part_type': 'engine-plugin-aws',
+                'env_path': ''
             },
             {
-                'part_type' :  'engine-plugin-azure',
-                'env_path' : ''
+                'part_type': 'engine-plugin-azure',
+                'env_path': ''
             }
         ],
-        'GENERATION_BIN_DIR' : [
+        'GENERATION_BIN_DIR': [
             {
-                'part_type' :  'engine-binary',
-                'env_path' : ''
+                'part_type': 'engine-binary',
+                'env_path': ''
             }
         ],
-        'GENERATION_BASE_DIR'   : [
+        'GENERATION_BASE_DIR': [
             {
-                'part_type' :  'executor-bash',
-                'env_path' : ''
+                'part_type': 'executor-bash',
+                'env_path': ''
             }
         ],
-        'GENERATION_DIR' : [
+        'GENERATION_DIR': [
             {
-                'part_type' :  'executor-bash',
-                'env_path' : 'cli'
+                'part_type': 'executor-bash',
+                'env_path': 'cli'
             }
         ],
-        'AUTOMATION_DIR' : [
+        'AUTOMATION_DIR': [
             {
-                'part_type' :  'executor-bash',
-                'env_path' : 'automation/jenkins/aws'
+                'part_type': 'executor-bash',
+                'env_path': 'automation/jenkins/aws'
             }
         ],
-        'AUTOMATION_BASE_DIR'  : [
+        'AUTOMATION_BASE_DIR': [
             {
-                'part_type' :  'executor-bash',
-                'env_path' : 'automation'
+                'part_type': 'executor-bash',
+                'env_path': 'automation'
             }
         ],
     }
@@ -147,13 +146,13 @@ class EngineInterface(ABC):
         try:
             source = self._sources[source_name]
         except KeyError:
-            raise  BackendException(f'source {source_name} not found in engine')
+            raise BackendException(f'source {source_name} not found in engine')
 
         return source
 
     def _get_engine_source_dir(self, source_name):
         source = self._get_source(source_name)
-        return os.path.join(self.install_path, source.name )
+        return os.path.join(self.install_path, source.name)
 
     def load_install_state(self):
         if os.path.isfile(self.install_state_file):
@@ -199,12 +198,12 @@ class GlobalEngine(EngineInterface):
             source.pull(source_dir)
 
         self.install_state = {
-            'name' : self.name,
-            'description' : self.description,
-            'hidden' : self.hidden,
-            'digest' : self.digest,
-            'part_paths' : self._set_part_paths(),
-            'source_digests' : {}
+            'name': self.name,
+            'description': self.description,
+            'hidden': self.hidden,
+            'digest': self.digest,
+            'part_paths': self._set_part_paths(),
+            'source_digests': {},
         }
         self.save_install_state()
 
@@ -225,11 +224,11 @@ class Engine(EngineInterface):
         self.digest = 'sha256:' + hashlib.sha256(':'.join(source_digests.values()).encode('utf-8')).hexdigest()
 
         self.install_state = {
-            'name' : self.name,
-            'description' : self.description,
-            'hidden' : self.hidden,
-            'digest' : self.digest,
-            'part_paths' : self._set_part_paths(),
-            'source_digests' : source_digests
+            'name': self.name,
+            'description': self.description,
+            'hidden': self.hidden,
+            'digest': self.digest,
+            'part_paths': self._set_part_paths(),
+            'source_digests': source_digests,
         }
         self.save_install_state()

--- a/hamlet-cli/hamlet/backend/engine/engine_loader.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_loader.py
@@ -85,7 +85,7 @@ class GlobalEngineLoader(EngineLoader):
 
 class InstalledEngineLoader(EngineLoader):
     '''
-    Loads the existing engines with a base engine that we can start with
+    Loads the installed engines to handle failures in loading external engines
     '''
     engine_states = []
     with os.scandir(ENGINE_STORE_ENGINES_DIR) as engines:
@@ -116,13 +116,13 @@ class InstalledEngineLoader(EngineLoader):
 class UnicycleEngineLoader(EngineLoader):
     '''
     Provides the latest builds of all official hamlet components
-    Each component is sourced directly from the code build image that is created on commit to the default branch
+    Each component is sourced directly from the image that is created on commit to the default branch
     '''
 
     engine_sources = [
         ContainerEngineSource(
             name='engine',
-            description='hamlet core components',
+            description='hamlet core engine',
             registry_url='https://ghcr.io',
             repository='hamlet-io/engine',
             tag='latest'
@@ -171,7 +171,7 @@ class UnicycleEngineLoader(EngineLoader):
 
     engine = Engine(
         name='unicycle',
-        description='Latest builds of the official parts'
+        description='Latest build of the official components'
     )
 
     engine.parts = engine_parts

--- a/hamlet-cli/hamlet/backend/engine/engine_loader.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_loader.py
@@ -5,8 +5,20 @@ from abc import ABC
 
 from .engine import Engine, InstalledEngine, GlobalEngine
 from .engine_source import ContainerEngineSource, ShimPathEngineSource
-from .engine_part import CoreEnginePart, AWSEnginePluginPart, AzureEnginePluginPart, CMDBEnginePluginPart, BinaryEnginePart, BashExecutorEnginePart
-from .common import ENGINE_GLOBAL_NAME, ENGINE_STORE_ENGINES_DIR, ENGINE_STORE_ENGINE_STATE_FILENAME
+from .engine_part import (
+    CoreEnginePart,
+    AWSEnginePluginPart,
+    AzureEnginePluginPart,
+    CMDBEnginePluginPart,
+    BinaryEnginePart,
+    BashExecutorEnginePart
+)
+from .common import (
+    ENGINE_GLOBAL_NAME,
+    ENGINE_STORE_ENGINES_DIR,
+    ENGINE_STORE_ENGINE_STATE_FILENAME
+)
+
 
 class EngineLoader(ABC):
     def __init__(self):
@@ -68,7 +80,7 @@ class GlobalEngineLoader(EngineLoader):
     def __init__(self):
         super().__init__()
 
-        self._engines = [ self.engine ]
+        self._engines = [self.engine]
 
 
 class InstalledEngineLoader(EngineLoader):
@@ -168,4 +180,4 @@ class UnicycleEngineLoader(EngineLoader):
     def __init__(self):
         super().__init__()
 
-        self._engines = [ self.engine ]
+        self._engines = [self.engine]

--- a/hamlet-cli/hamlet/backend/engine/engine_loader.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_loader.py
@@ -1,0 +1,171 @@
+import os
+import json
+
+from abc import ABC
+
+from .engine import Engine, InstalledEngine, GlobalEngine
+from .engine_source import ContainerEngineSource, ShimPathEngineSource
+from .engine_part import CoreEnginePart, AWSEnginePluginPart, AzureEnginePluginPart, CMDBEnginePluginPart, BinaryEnginePart, BashExecutorEnginePart
+from .common import ENGINE_GLOBAL_NAME, ENGINE_STORE_ENGINES_DIR, ENGINE_STORE_ENGINE_STATE_FILENAME
+
+class EngineLoader(ABC):
+    def __init__(self):
+        self._engines = []
+
+    @property
+    def engines(self):
+        for engine in self._engines:
+            yield engine
+
+
+class GlobalEngineLoader(EngineLoader):
+    '''
+    A hidden engine used to provide the path mappings for the shim global engine
+    '''
+    engine_source = [
+        ShimPathEngineSource(
+            name='shim',
+            description='shim based root dir source'
+        )
+    ]
+
+    engine_parts = [
+        CoreEnginePart(
+            source_path='engine-core',
+            source_name='shim'
+        ),
+        BashExecutorEnginePart(
+            source_path='executor-bash',
+            source_name='shim'
+        ),
+        AWSEnginePluginPart(
+            source_path='engine-plugin-aws',
+            source_name='shim'
+        ),
+        AzureEnginePluginPart(
+            source_path='engine-plugin-azure',
+            source_name='shim'
+        ),
+        CMDBEnginePluginPart(
+            source_path='engine-plugin-cmdb',
+            source_name='shim'
+        ),
+        BinaryEnginePart(
+            source_path='engine-binary',
+            source_name='shim'
+        )
+    ]
+
+    engine = GlobalEngine(
+        name=ENGINE_GLOBAL_NAME,
+        description='The engine used to provide global part mappings',
+        hidden=True
+    )
+    engine.parts = engine_parts
+    engine.sources = engine_source
+    engine.install()
+
+    def __init__(self):
+        super().__init__()
+
+        self._engines = [ self.engine ]
+
+
+class InstalledEngineLoader(EngineLoader):
+    '''
+    Loads the existing engines with a base engine that we can start with
+    '''
+    engine_states = []
+    with os.scandir(ENGINE_STORE_ENGINES_DIR) as engines:
+        for engine in engines:
+            if engine.is_dir():
+                with os.scandir(engine) as sources:
+                    for source in sources:
+                        if source.is_file() and source.name == ENGINE_STORE_ENGINE_STATE_FILENAME:
+                            with open(source, 'r') as f:
+                                engine_states.append(json.load(f))
+
+    engines = []
+    for engine_state in engine_states:
+        engines.append(
+            InstalledEngine(
+                name=engine_state['name'],
+                description=engine_state['description'],
+                digest=engine_state['digest'],
+                hidden=engine_state['hidden'],
+            )
+        )
+
+    def __init__(self):
+        super().__init__()
+        self._engines = self.engines
+
+
+class UnicycleEngineLoader(EngineLoader):
+    '''
+    Provides the latest builds of all official hamlet components
+    Each component is sourced directly from the code build image that is created on commit to the default branch
+    '''
+
+    engine_sources = [
+        ContainerEngineSource(
+            name='engine',
+            description='hamlet core components',
+            registry_url='https://ghcr.io',
+            repository='hamlet-io/engine',
+            tag='latest'
+        ),
+        ContainerEngineSource(
+            name='executor-bash',
+            description='hamlet bash executor',
+            registry_url='https://ghcr.io',
+            repository='hamlet-io/executor-bash',
+            tag='latest'
+        ),
+        ContainerEngineSource(
+            name='engine-plugin-aws',
+            description='hamlet aws engine plugin',
+            registry_url='https://ghcr.io',
+            repository='hamlet-io/engine-plugin-aws',
+            tag='latest'
+        ),
+        ContainerEngineSource(
+            name='engine-plugin-azure',
+            description='hamlet azure engine plugin',
+            registry_url='https://ghcr.io',
+            repository='hamlet-io/engine-plugin-azure',
+            tag='latest'
+        ),
+    ]
+
+    engine_parts = [
+        CoreEnginePart(
+            source_path='',
+            source_name='engine'
+        ),
+        BashExecutorEnginePart(
+            source_path='',
+            source_name='executor-bash'
+        ),
+        AWSEnginePluginPart(
+            source_path='',
+            source_name='engine-plugin-aws'
+        ),
+        AzureEnginePluginPart(
+            source_path='',
+            source_name='engine-plugin-azure'
+        ),
+    ]
+
+    engine = Engine(
+        name='unicycle',
+        description='Latest builds of the official parts'
+    )
+
+    engine.parts = engine_parts
+    engine.sources = engine_sources
+
+    def __init__(self):
+        super().__init__()
+
+        self._engines = [ self.engine ]

--- a/hamlet-cli/hamlet/backend/engine/engine_loader.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_loader.py
@@ -15,8 +15,7 @@ from .engine_part import (
 )
 from .common import (
     ENGINE_GLOBAL_NAME,
-    ENGINE_STORE_ENGINES_DIR,
-    ENGINE_STORE_ENGINE_STATE_FILENAME
+    ENGINE_STATE_FILE_NAME
 )
 
 
@@ -24,8 +23,7 @@ class EngineLoader(ABC):
     def __init__(self):
         self._engines = []
 
-    @property
-    def engines(self):
+    def load(self):
         for engine in self._engines:
             yield engine
 
@@ -34,83 +32,83 @@ class GlobalEngineLoader(EngineLoader):
     '''
     A hidden engine used to provide the path mappings for the shim global engine
     '''
-    engine_source = [
-        ShimPathEngineSource(
-            name='shim',
-            description='shim based root dir source'
-        )
-    ]
-
-    engine_parts = [
-        CoreEnginePart(
-            source_path='engine-core',
-            source_name='shim'
-        ),
-        BashExecutorEnginePart(
-            source_path='executor-bash',
-            source_name='shim'
-        ),
-        AWSEnginePluginPart(
-            source_path='engine-plugin-aws',
-            source_name='shim'
-        ),
-        AzureEnginePluginPart(
-            source_path='engine-plugin-azure',
-            source_name='shim'
-        ),
-        CMDBEnginePluginPart(
-            source_path='engine-plugin-cmdb',
-            source_name='shim'
-        ),
-        BinaryEnginePart(
-            source_path='engine-binary',
-            source_name='shim'
-        )
-    ]
-
-    engine = GlobalEngine(
-        name=ENGINE_GLOBAL_NAME,
-        description='The engine used to provide global part mappings',
-        hidden=True
-    )
-    engine.parts = engine_parts
-    engine.sources = engine_source
-    engine.install()
-
     def __init__(self):
         super().__init__()
 
-        self._engines = [self.engine]
+        engine_source = [
+            ShimPathEngineSource(
+                name='shim',
+                description='shim based root dir source'
+            )
+        ]
+
+        engine_parts = [
+            CoreEnginePart(
+                source_path='engine-core',
+                source_name='shim'
+            ),
+            BashExecutorEnginePart(
+                source_path='executor-bash',
+                source_name='shim'
+            ),
+            AWSEnginePluginPart(
+                source_path='engine-plugin-aws',
+                source_name='shim'
+            ),
+            AzureEnginePluginPart(
+                source_path='engine-plugin-azure',
+                source_name='shim'
+            ),
+            CMDBEnginePluginPart(
+                source_path='engine-plugin-cmdb',
+                source_name='shim'
+            ),
+            BinaryEnginePart(
+                source_path='engine-binary',
+                source_name='shim'
+            )
+        ]
+
+        engine = GlobalEngine(
+            name=ENGINE_GLOBAL_NAME,
+            description='The engine used to provide global part mappings',
+            hidden=True
+        )
+        engine.parts = engine_parts
+        engine.sources = engine_source
+
+        self._engines = [engine]
 
 
 class InstalledEngineLoader(EngineLoader):
     '''
     Loads the installed engines to handle failures in loading external engines
     '''
-    engine_states = []
-    with os.scandir(ENGINE_STORE_ENGINES_DIR) as engines:
-        for engine in engines:
-            if engine.is_dir():
-                with os.scandir(engine) as sources:
-                    for source in sources:
-                        if source.is_file() and source.name == ENGINE_STORE_ENGINE_STATE_FILENAME:
-                            with open(source, 'r') as f:
-                                engine_states.append(json.load(f))
 
-    engines = []
-    for engine_state in engine_states:
-        engines.append(
-            InstalledEngine(
+    def __init__(self, engine_dir):
+        super().__init__()
+        self.engine_dir = engine_dir
+
+    def load(self):
+
+        engine_states = []
+        if os.path.isdir(self.engine_dir):
+            with os.scandir(self.engine_dir) as engines:
+                for engine in engines:
+                    if engine.is_dir():
+                        with os.scandir(engine) as sources:
+                            for source in sources:
+                                if source.is_file() and source.name == ENGINE_STATE_FILE_NAME:
+                                    with open(source, 'r') as f:
+                                        engine_states.append(json.load(f))
+
+        for engine_state in engine_states:
+            yield InstalledEngine(
                 name=engine_state['name'],
                 description=engine_state['description'],
                 digest=engine_state['digest'],
                 hidden=engine_state['hidden'],
             )
-        )
-
-    def __init__(self):
-        super().__init__()
-        self._engines = self.engines
 
 
 class UnicycleEngineLoader(EngineLoader):
@@ -119,65 +117,64 @@ class UnicycleEngineLoader(EngineLoader):
     Each component is sourced directly from the image that is created on commit to the default branch
     '''
 
-    engine_sources = [
-        ContainerEngineSource(
-            name='engine',
-            description='hamlet core engine',
-            registry_url='https://ghcr.io',
-            repository='hamlet-io/engine',
-            tag='latest'
-        ),
-        ContainerEngineSource(
-            name='executor-bash',
-            description='hamlet bash executor',
-            registry_url='https://ghcr.io',
-            repository='hamlet-io/executor-bash',
-            tag='latest'
-        ),
-        ContainerEngineSource(
-            name='engine-plugin-aws',
-            description='hamlet aws engine plugin',
-            registry_url='https://ghcr.io',
-            repository='hamlet-io/engine-plugin-aws',
-            tag='latest'
-        ),
-        ContainerEngineSource(
-            name='engine-plugin-azure',
-            description='hamlet azure engine plugin',
-            registry_url='https://ghcr.io',
-            repository='hamlet-io/engine-plugin-azure',
-            tag='latest'
-        ),
-    ]
-
-    engine_parts = [
-        CoreEnginePart(
-            source_path='',
-            source_name='engine'
-        ),
-        BashExecutorEnginePart(
-            source_path='',
-            source_name='executor-bash'
-        ),
-        AWSEnginePluginPart(
-            source_path='',
-            source_name='engine-plugin-aws'
-        ),
-        AzureEnginePluginPart(
-            source_path='',
-            source_name='engine-plugin-azure'
-        ),
-    ]
-
-    engine = Engine(
-        name='unicycle',
-        description='Latest build of the official components'
-    )
-
-    engine.parts = engine_parts
-    engine.sources = engine_sources
-
     def __init__(self):
         super().__init__()
 
-        self._engines = [self.engine]
+        engine_sources = [
+            ContainerEngineSource(
+                name='engine',
+                description='hamlet core engine',
+                registry_url='https://ghcr.io',
+                repository='hamlet-io/engine',
+                tag='latest'
+            ),
+            ContainerEngineSource(
+                name='executor-bash',
+                description='hamlet bash executor',
+                registry_url='https://ghcr.io',
+                repository='hamlet-io/executor-bash',
+                tag='latest'
+            ),
+            ContainerEngineSource(
+                name='engine-plugin-aws',
+                description='hamlet aws engine plugin',
+                registry_url='https://ghcr.io',
+                repository='hamlet-io/engine-plugin-aws',
+                tag='latest'
+            ),
+            ContainerEngineSource(
+                name='engine-plugin-azure',
+                description='hamlet azure engine plugin',
+                registry_url='https://ghcr.io',
+                repository='hamlet-io/engine-plugin-azure',
+                tag='latest'
+            ),
+        ]
+
+        engine_parts = [
+            CoreEnginePart(
+                source_path='',
+                source_name='engine'
+            ),
+            BashExecutorEnginePart(
+                source_path='',
+                source_name='executor-bash'
+            ),
+            AWSEnginePluginPart(
+                source_path='',
+                source_name='engine-plugin-aws'
+            ),
+            AzureEnginePluginPart(
+                source_path='',
+                source_name='engine-plugin-azure'
+            ),
+        ]
+
+        engine = Engine(
+            name='unicycle',
+            description='Latest build of the official components'
+        )
+        engine.parts = engine_parts
+        engine.sources = engine_sources
+
+        self._engines = [engine]

--- a/hamlet-cli/hamlet/backend/engine/engine_part.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_part.py
@@ -1,0 +1,50 @@
+import os
+from marshmallow import Schema, fields
+from abc import ABC, abstractmethod
+
+
+class EnginePartStateSchema(Schema):
+    name = fields.String()
+    description = fields.String()
+    source_path = fields.String()
+    source_name = fields.String()
+
+
+class EnginePartInterface(ABC):
+
+    type = None
+    description = ''
+
+    def __init__(self, source_name, source_path):
+        self.source_path = source_path
+        self.source_name = source_name
+
+
+class CoreEnginePart(EnginePartInterface):
+    type = 'core-engine'
+    description = 'core engine source'
+
+
+class AWSEnginePluginPart(EnginePartInterface):
+    type = 'engine-plugin-aws'
+    description = 'default aws engine plugin'
+
+
+class AzureEnginePluginPart(EnginePartInterface):
+    type = 'engine-plugin-azure'
+    description = 'default azure engine plugin'
+
+
+class CMDBEnginePluginPart(EnginePartInterface):
+    type = 'engine-plugin-cmdb'
+    description = 'cmdb input engine plugin'
+
+
+class BinaryEnginePart(EnginePartInterface):
+    type = 'engine-binary'
+    description = 'cmdb input engine plugin'
+
+
+class BashExecutorEnginePart(EnginePartInterface):
+    type = 'executor-bash'
+    description = 'bash based executor'

--- a/hamlet-cli/hamlet/backend/engine/engine_part.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_part.py
@@ -1,6 +1,5 @@
-import os
 from marshmallow import Schema, fields
-from abc import ABC, abstractmethod
+from abc import ABC
 
 
 class EnginePartStateSchema(Schema):

--- a/hamlet-cli/hamlet/backend/engine/engine_part.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_part.py
@@ -41,7 +41,7 @@ class CMDBEnginePluginPart(EnginePartInterface):
 
 class BinaryEnginePart(EnginePartInterface):
     type = 'engine-binary'
-    description = 'cmdb input engine plugin'
+    description = 'hamlet freemarker wrapper binary'
 
 
 class BashExecutorEnginePart(EnginePartInterface):

--- a/hamlet-cli/hamlet/backend/engine/engine_part.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_part.py
@@ -1,16 +1,12 @@
-from marshmallow import Schema, fields
 from abc import ABC
 
 
-class EnginePartStateSchema(Schema):
-    name = fields.String()
-    description = fields.String()
-    source_path = fields.String()
-    source_name = fields.String()
-
-
 class EnginePartInterface(ABC):
-
+    '''
+    An engine part defines a functional component of the hamlet tooling
+    Each part has a fixed type with instances have a link to a source that
+    has the component tooling
+    '''
     type = None
     description = ''
 

--- a/hamlet-cli/hamlet/backend/engine/engine_source.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_source.py
@@ -1,0 +1,82 @@
+import os
+from abc import ABC, abstractmethod
+
+from hamlet.backend.container_registry import get_registry_login_token, get_registry_image_manifest, pull_registry_image_to_dir
+
+
+class EngineSourceInterface(ABC):
+
+    def __init__(self, name, description=''):
+        self.name = name
+        self.description = description
+
+    @abstractmethod
+    def pull(self, dst_dir):
+        '''
+        Pull the source to a local directory
+        '''
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def digest(self):
+        '''
+        Return a digest of the source to use for verification and version updates
+        '''
+        raise NotImplementedError
+
+
+class ShimPathEngineSource(EngineSourceInterface):
+    '''
+    Sets a standard source path to use for shim based providers
+    '''
+
+    def pull(self, dst_dir):
+        if not os.path.isdir(dst_dir):
+            os.makedirs(dst_dir)
+
+    @property
+    def digest(self):
+        return ''
+
+
+class ContainerEngineSource(EngineSourceInterface):
+    '''
+    Container based engine source which uses docker registries to pull content
+    '''
+
+    def __init__(self, name, description, registry_url, repository, tag, username=None, password=None):
+        super().__init__(name, description)
+
+        self.registry_url = registry_url
+        self.repository = repository
+        self.tag = tag
+
+        self.username = username
+        self.password = password
+
+    def _get_auth_token(self):
+        return get_registry_login_token(
+            self.registry_url,
+            self.repository,
+            username=self.username,
+            password=self.password
+        )
+
+    def _manifest(self, auth_token=None):
+        if auth_token is None:
+            auth_token = self._get_auth_token()
+        return get_registry_image_manifest(self.registry_url, self.repository, self.tag, self._get_auth_token())
+
+    def pull(self, dst_dir):
+
+        auth_token = self._get_auth_token()
+        manifest = self._manifest(auth_token)
+
+        pull_registry_image_to_dir(self.registry_url, self.repository, manifest, auth_token, dst_dir)
+
+    @property
+    def digest(self):
+        manifest = self._manifest()
+
+        return manifest['config']['digest']

--- a/hamlet-cli/hamlet/backend/engine/engine_source.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_source.py
@@ -1,7 +1,11 @@
 import os
 from abc import ABC, abstractmethod
 
-from hamlet.backend.container_registry import get_registry_login_token, get_registry_image_manifest, pull_registry_image_to_dir
+from hamlet.backend.container_registry import (
+    get_registry_login_token,
+    get_registry_image_manifest,
+    pull_registry_image_to_dir
+)
 
 
 class EngineSourceInterface(ABC):

--- a/hamlet-cli/hamlet/backend/query/__init__.py
+++ b/hamlet-cli/hamlet/backend/query/__init__.py
@@ -30,7 +30,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     query = Query(
         cwd,

--- a/hamlet-cli/hamlet/backend/run/expo_app_publish/__init__.py
+++ b/hamlet-cli/hamlet/backend/run/expo_app_publish/__init__.py
@@ -17,7 +17,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     options = {
         '-u': deployment_unit,

--- a/hamlet-cli/hamlet/backend/run/lambda_func/__init__.py
+++ b/hamlet-cli/hamlet/backend/run/lambda_func/__init__.py
@@ -13,7 +13,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     options = {
         '-f': function_id,

--- a/hamlet-cli/hamlet/backend/run/pipeline/__init__.py
+++ b/hamlet-cli/hamlet/backend/run/pipeline/__init__.py
@@ -15,7 +15,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     options = {
         '-i': component,

--- a/hamlet-cli/hamlet/backend/run/sentry_release/__init__.py
+++ b/hamlet-cli/hamlet/backend/run/sentry_release/__init__.py
@@ -13,7 +13,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     options = {
         '-m': sentry_source_map_s3_url,

--- a/hamlet-cli/hamlet/backend/run/task/__init__.py
+++ b/hamlet-cli/hamlet/backend/run/task/__init__.py
@@ -20,7 +20,8 @@ def run(
     product=None,
     environment=None,
     segment=None,
-    _is_cli=False
+    _is_cli=False,
+    **kwargs
 ):
     options = {
         '-c': container_id,

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -1,15 +1,37 @@
 import click
-from hamlet.command.common import decorators
 
+from hamlet.command.common import decorators
+from hamlet.command.common.exceptions import backend_handler
+from hamlet.backend.engine import engine_store
+from hamlet.env import set_engine_env
 
 @click.group('root')
+@decorators.common_engine_options
 @decorators.common_district_options
 @decorators.common_cli_config_options
 @decorators.common_generation_options
 @decorators.common_logging_options
 @click.pass_context
+@backend_handler()
 def root(ctx, opts):
     '''
     hamlet deploy
     '''
-    pass
+    if opts.engine is not None:
+        engine = engine_store.get_engine(opts.engine)
+
+        if not engine.installed:
+            click.echo(
+                click.style(f'[*] Installing hamlet engine - {engine.name}', fg='yellow'),
+                err=True
+            )
+            engine.install()
+
+        if engine_store.global_engine is None:
+            click.echo(
+                click.style(f'[*] No global engine defined, setting global engine - {engine.name}', fg='yellow'),
+                err=True
+            )
+            engine_store.global_engine = engine.name
+
+        set_engine_env(engine.environment)

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -3,6 +3,7 @@ import click
 from hamlet.command.common import decorators
 from hamlet.command.common.exceptions import backend_handler
 from hamlet.backend.engine import engine_store
+from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME, ENGINE_DEFAULT_GLOBAL_ENGINE
 from hamlet.env import set_engine_env
 
 
@@ -18,21 +19,30 @@ def root(ctx, opts):
     '''
     hamlet deploy
     '''
+    use_global_env = False
+
     if opts.engine is not None:
         engine = engine_store.get_engine(opts.engine)
+    else:
+        engine = engine_store.get_engine(ENGINE_DEFAULT_GLOBAL_ENGINE)
+        use_global_env = True
 
-        if not engine.installed:
-            click.echo(
-                click.style(f'[*] Installing hamlet engine - {engine.name}', fg='yellow'),
-                err=True
-            )
-            engine.install()
+    if not engine.installed:
+        click.echo(
+            click.style(f'[*] Installing hamlet engine - {engine.name}', fg='yellow'),
+            err=True
+        )
+        engine.install()
 
-        if engine_store.global_engine is None:
-            click.echo(
-                click.style(f'[*] No global engine defined, setting global engine - {engine.name}', fg='yellow'),
-                err=True
-            )
-            engine_store.global_engine = engine.name
+    if engine_store.global_engine is None:
+        click.echo(
+            click.style(f'[*] Global engine not set using the default global engine - {engine.name}', fg='yellow'),
+            err=True
+        )
+        engine_store.global_engine = ENGINE_DEFAULT_GLOBAL_ENGINE
 
+    if use_global_env:
+        global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
+        set_engine_env(global_engine.environment)
+    else:
         set_engine_env(engine.environment)

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -21,6 +21,10 @@ def root(ctx, opts):
     '''
     use_global_env = False
 
+    global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
+    if not global_engine.installed:
+        global_engine.install()
+
     if opts.engine is not None:
         engine = engine_store.get_engine(opts.engine)
     else:
@@ -42,7 +46,6 @@ def root(ctx, opts):
         engine_store.global_engine = ENGINE_DEFAULT_GLOBAL_ENGINE
 
     if use_global_env:
-        global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
         set_engine_env(global_engine.environment)
     else:
         set_engine_env(engine.environment)

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -5,6 +5,7 @@ from hamlet.command.common.exceptions import backend_handler
 from hamlet.backend.engine import engine_store
 from hamlet.env import set_engine_env
 
+
 @click.group('root')
 @decorators.common_engine_options
 @decorators.common_district_options

--- a/hamlet-cli/hamlet/command/common/config.py
+++ b/hamlet-cli/hamlet/command/common/config.py
@@ -7,6 +7,7 @@ from hamlet.env import HAMLET_HOME_DIR
 
 hamlet_config_dir = os.path.join(HAMLET_HOME_DIR, 'config')
 
+
 class ConfigParam(Param):
     # For compatibility with click>=7.0
     def __init__(self, *args, **kwargs):
@@ -32,6 +33,7 @@ class ConfigParam(Param):
         else:
             msg = f'{self.name} in a config file'
         return msg
+
 
 class ConfigSchema(object):
     '''Schema for standard configuration.'''

--- a/hamlet-cli/hamlet/command/common/config.py
+++ b/hamlet-cli/hamlet/command/common/config.py
@@ -2,7 +2,10 @@ import click
 import os
 
 from click_configfile import ConfigFileReader, Param, SectionSchema, matches_section
+from hamlet.env import HAMLET_HOME_DIR
 
+
+hamlet_config_dir = os.path.join(HAMLET_HOME_DIR, 'config')
 
 class ConfigParam(Param):
     # For compatibility with click>=7.0
@@ -30,7 +33,6 @@ class ConfigParam(Param):
             msg = f'{self.name} in a config file'
         return msg
 
-
 class ConfigSchema(object):
     '''Schema for standard configuration.'''
 
@@ -44,15 +46,11 @@ class ConfigSchema(object):
         product = ConfigParam(name='product', type=str)
         environment = ConfigParam(name='environment', type=str)
         segment = ConfigParam(name='segment', type=str)
+        engine = ConfigParam(name='engine', type=str)
 
     @matches_section("profile:*")
     class Profile(Default):
         '''Profile-specific configuration schema.'''
-
-
-def get_default_config_path():
-    '''Get the default path to config files.'''
-    return click.get_app_dir(app_name='hamlet', force_posix=True)
 
 
 class ConfigReader(ConfigFileReader):
@@ -60,7 +58,7 @@ class ConfigReader(ConfigFileReader):
 
     config_files = ['config']
     config_name = 'standard'
-    config_searchpath = [get_default_config_path()]
+    config_searchpath = [HAMLET_HOME_DIR, hamlet_config_dir]
     config_section_schemas = [ConfigSchema.Default, ConfigSchema.Profile]
 
     @classmethod
@@ -215,6 +213,16 @@ class Options:
     def segment(self, value):
         '''Set the segment setting'''
         self._set_option('segment', value)
+
+    @property
+    def engine(self):
+        '''Get the engine to use for the district'''
+        return self._get_option('engine')
+
+    @engine.setter
+    def engine(self, value):
+        '''Set the engine setting'''
+        self._set_option('engine', value)
 
     @property
     def generation_framework(self):

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -78,7 +78,6 @@ def common_engine_options(func):
     @click.option(
         '--engine',
         envvar='HAMLET_ENGINE',
-        default='unicycle',
         help='The name of the engine to use',
     )
     @click.pass_context

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -71,6 +71,7 @@ def common_logging_options(func):
 
     return wrapper
 
+
 def common_engine_options(func):
     '''Add common options for the engine'''
 
@@ -92,6 +93,7 @@ def common_engine_options(func):
         return ctx.invoke(func, *args, **kwargs)
 
     return wrapper
+
 
 def common_generation_options(func):
     '''Add commmon options for generation'''

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -71,6 +71,27 @@ def common_logging_options(func):
 
     return wrapper
 
+def common_engine_options(func):
+    '''Add common options for the engine'''
+
+    @click.option(
+        '--engine',
+        envvar='HAMLET_ENGINE',
+        default='unicycle',
+        help='The name of the engine to use',
+    )
+    @click.pass_context
+    @functools.wraps(func)
+    def wrapper(ctx, *args, **kwargs):
+        '''
+        Engine configuration options
+        '''
+        opts = ctx.ensure_object(Options)
+        opts.engine = kwargs.pop('engine')
+        kwargs['opts'] = opts
+        return ctx.invoke(func, *args, **kwargs)
+
+    return wrapper
 
 def common_generation_options(func):
     '''Add commmon options for generation'''

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -1,0 +1,165 @@
+import click
+import os
+import shutil
+
+from tabulate import tabulate
+
+from hamlet.command import root as cli
+from hamlet.command.common import exceptions
+from hamlet.command.common import config
+
+from hamlet.backend.engine import engine_store
+from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME, ENGINE_STORE_DIR
+from hamlet.command.common.display import json_or_table_option, wrap_text
+
+
+def engines_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row['name']),
+                wrap_text(row['description']),
+                wrap_text(row['installed']),
+                wrap_text(row['global']),
+            ]
+        )
+    return tabulate(
+        tablerows,
+        headers=['Name', 'Description', 'Installed', 'GlobalEngine'],
+        tablefmt='github'
+    )
+
+
+@cli.group('engine')
+def group():
+    """
+    Manage the setup of your hamlet workspace
+    """
+
+
+@group.command(
+    'list-engines',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@json_or_table_option(engines_table)
+@exceptions.backend_handler()
+def list_engines():
+    '''
+    Lists the available hamlet engines
+    '''
+    data = []
+
+    for engine in engine_store.engines:
+        data.append(
+            {
+                'name' : engine.name,
+                'description' : engine.description,
+                'installed' : engine.installed,
+                'digest' : engine.digest,
+                'global' : True if engine.name == engine_store.global_engine else False
+            }
+        )
+    return data
+
+
+@group.command(
+    'clean-engines',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@exceptions.backend_handler()
+def clean_engines():
+    '''
+    Clean local engine store
+    '''
+    if os.path.isdir(ENGINE_STORE_DIR):
+        shutil.rmtree(ENGINE_STORE_DIR)
+
+
+@group.command(
+    'install-engine',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.option(
+    '-n',
+    '--name',
+    default='unicycle',
+    show_default=True,
+    help='The name of the engine to install'
+)
+@exceptions.backend_handler()
+def install_engine(name):
+    '''
+    Get and install an hamlet engine version
+    '''
+    engine = engine_store.get_engine(name)
+    engine.install()
+
+
+@group.command(
+    'set-engine',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.argument(
+    'name',
+    required=True,
+    type=click.STRING
+)
+@exceptions.backend_handler()
+def set_engine(name):
+    '''
+    sets the global default engine to use
+    '''
+    engine = engine_store.get_engine(name)
+
+    if not engine.installed:
+        engine.install()
+
+    click.echo(f'default engine set to {name}')
+    engine_store.global_engine = name
+
+
+@group.command('env')
+@click.argument(
+    'environment_variable',
+    required=False,
+    type=click.STRING,
+)
+@click.option(
+    '-n',
+    '--engine-name',
+    default=ENGINE_GLOBAL_NAME,
+    show_default=True,
+    help='The name of the engine to get env for'
+)
+@exceptions.backend_handler()
+@config.pass_options
+def env(options, environment_variable, engine_name):
+    """
+    Get the env variable config for hamlet
+    """
+
+    engine = engine_store.get_engine(engine_name)
+
+    if environment_variable is None:
+        click.echo('# run eval $(hamlet engine env) to set variables')
+        for k,v in engine.environment.items():
+            click.echo(f'export {k}="{v}"')
+
+    else:
+        try:
+            click.echo(engine.environment[environment_variable])
+        except KeyError:
+            click.echo('')

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -9,7 +9,7 @@ from hamlet.command.common import exceptions
 from hamlet.command.common import config
 
 from hamlet.backend.engine import engine_store
-from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME, ENGINE_STORE_DIR
+from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
 from hamlet.command.common.display import json_or_table_option, wrap_text
 
 
@@ -78,8 +78,9 @@ def clean_engines():
     '''
     Clean local engine store
     '''
-    if os.path.isdir(ENGINE_STORE_DIR):
-        shutil.rmtree(ENGINE_STORE_DIR)
+
+    if os.path.isdir(engine_store.store_dir):
+        shutil.rmtree(engine_store.store_dir)
 
 
 @group.command(

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -56,11 +56,11 @@ def list_engines():
     for engine in engine_store.engines:
         data.append(
             {
-                'name' : engine.name,
-                'description' : engine.description,
-                'installed' : engine.installed,
-                'digest' : engine.digest,
-                'global' : True if engine.name == engine_store.global_engine else False
+                'name': engine.name,
+                'description': engine.description,
+                'installed': engine.installed,
+                'digest': engine.digest,
+                'global': True if engine.name == engine_store.global_engine else False
             }
         )
     return data
@@ -155,7 +155,7 @@ def env(options, environment_variable, engine_name):
 
     if environment_variable is None:
         click.echo('# run eval $(hamlet engine env) to set variables')
-        for k,v in engine.environment.items():
+        for k, v in engine.environment.items():
             click.echo(f'export {k}="{v}"')
 
     else:

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -34,7 +34,7 @@ def engines_table(data):
 @cli.group('engine')
 def group():
     """
-    Manage the setup of your hamlet workspace
+    Manage the engine used by the executor
     """
 
 
@@ -49,7 +49,7 @@ def group():
 @exceptions.backend_handler()
 def list_engines():
     '''
-    Lists the available hamlet engines
+    Lists the available engines
     '''
     data = []
 
@@ -92,14 +92,13 @@ def clean_engines():
 @click.option(
     '-n',
     '--name',
-    default='unicycle',
-    show_default=True,
+    required=True,
     help='The name of the engine to install'
 )
 @exceptions.backend_handler()
 def install_engine(name):
     '''
-    Get and install an hamlet engine version
+    Install an engine
     '''
     engine = engine_store.get_engine(name)
     engine.install()
@@ -120,7 +119,7 @@ def install_engine(name):
 @exceptions.backend_handler()
 def set_engine(name):
     '''
-    sets the global default engine to use
+    Sets the global engine used
     '''
     engine = engine_store.get_engine(name)
 
@@ -137,21 +136,17 @@ def set_engine(name):
     required=False,
     type=click.STRING,
 )
-@click.option(
-    '-n',
-    '--engine-name',
-    default=ENGINE_GLOBAL_NAME,
-    show_default=True,
-    help='The name of the engine to get env for'
-)
 @exceptions.backend_handler()
 @config.pass_options
-def env(options, environment_variable, engine_name):
+def env(opts, environment_variable):
     """
-    Get the env variable config for hamlet
+    Get the environment variables for the current engine
     """
 
-    engine = engine_store.get_engine(engine_name)
+    if opts.engine is None:
+        engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
+    else:
+        engine = engine_store.get_engine(opts.engine)
 
     if environment_variable is None:
         click.echo('# run eval $(hamlet engine env) to set variables')

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -90,11 +90,10 @@ def clean_engines():
         max_content_width=240
     )
 )
-@click.option(
-    '-n',
-    '--name',
+@click.argument(
+    'name',
     required=True,
-    help='The name of the engine to install'
+    type=click.STRING
 )
 @exceptions.backend_handler()
 def install_engine(name):

--- a/hamlet-cli/hamlet/command/setup/__init__.py
+++ b/hamlet-cli/hamlet/command/setup/__init__.py
@@ -15,7 +15,7 @@ from hamlet.command.common.config import pass_options
 @pass_options
 def setup(options, **kwargs):
     '''
-    Sets up the local hamlet workspace
+    Loads the plugins defined as part of the current district
     '''
     args = {
         **options.opts,

--- a/hamlet-cli/hamlet/env.py
+++ b/hamlet-cli/hamlet/env.py
@@ -1,3 +1,14 @@
 import os
+import click
 
-GENERATION_DIR = os.environ.get('GENERATION_DIR')
+HAMLET_HOME_DIR = os.environ.get('HAMLET_HOME_DIR', click.get_app_dir(app_name='hamlet', force_posix=True, roaming=False) )
+ENGINE_ENV = {
+    'GENERATION_DIR' : os.environ.get('GENERATION_DIR')
+}
+
+def set_engine_env(env):
+    '''
+    Used by child processes to update the env global as required
+    '''
+    global ENGINE_ENV
+    ENGINE_ENV = env

--- a/hamlet-cli/hamlet/env.py
+++ b/hamlet-cli/hamlet/env.py
@@ -1,10 +1,15 @@
 import os
 import click
 
-HAMLET_HOME_DIR = os.environ.get('HAMLET_HOME_DIR', click.get_app_dir(app_name='hamlet', force_posix=True, roaming=False) )
+
+HAMLET_HOME_DIR = os.environ.get(
+    'HAMLET_HOME_DIR',
+    click.get_app_dir(app_name='hamlet', force_posix=True, roaming=False)
+)
 ENGINE_ENV = {
-    'GENERATION_DIR' : os.environ.get('GENERATION_DIR')
+    'GENERATION_DIR': os.environ.get('GENERATION_DIR')
 }
+
 
 def set_engine_env(env):
     '''

--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -43,6 +43,8 @@ setup(
         'marshmallow>=3.7.0,<4.0.0',
         'jmespath>=0.10.0<1.0.0',
         'importlib-resources>=5.1.2<6.0.0',
+        'www-authenticate>=0.9.2<1.0.0',
+        'requests>=2.25.1<3.0.0',
 
         # cfn-lint has issues with the latest networkx
         # Their requirements are installing the latest one

--- a/hamlet-cli/tests/unit/backend/engine/test_engine.py
+++ b/hamlet-cli/tests/unit/backend/engine/test_engine.py
@@ -1,0 +1,133 @@
+import tempfile
+import os
+import hashlib
+from unittest import mock
+
+from hamlet.backend.engine import EngineStore
+from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
+from hamlet.backend.engine.engine import Engine
+from hamlet.backend.engine.engine_loader import GlobalEngineLoader, InstalledEngineLoader, UnicycleEngineLoader
+from hamlet.backend.engine.engine_part import CoreEnginePart
+from hamlet.backend.engine.engine_source import ShimPathEngineSource
+
+
+def mock_container_registry():
+    def decorator(func):
+        @mock.patch('hamlet.backend.engine.engine_source.pull_registry_image_to_dir')
+        @mock.patch('hamlet.backend.engine.engine_source.get_registry_image_manifest')
+        @mock.patch('hamlet.backend.engine.engine_source.get_registry_login_token')
+        def wrapper(mock_login_token, mock_image_manifest, mock_image_to_dir, *args, **kwargs):
+
+            mock_image_manifest.return_value = {
+                'config': {
+                    'digest': 'config_digest[1]'
+                }
+            }
+
+            return func(mock_login_token, mock_image_manifest, mock_image_to_dir, *args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+def test_global_engine_loading():
+    '''
+    Tests that the basic global engine is loaded and can be found
+    '''
+    with tempfile.TemporaryDirectory() as store_dir:
+        engine_store = EngineStore(store_dir=store_dir)
+
+        engine_store.engine_loaders = [
+            GlobalEngineLoader()
+        ]
+
+        assert len(engine_store.engines) == 0
+
+        global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
+
+        assert global_engine.name == ENGINE_GLOBAL_NAME
+
+        global_engine.install()
+
+        assert os.path.isfile(global_engine.install_state_file)
+
+        generation_dir_path = os.path.join(global_engine.install_path, 'shim/executor-bash/cli')
+        assert global_engine.environment['GENERATION_DIR'] == generation_dir_path
+
+        automation_dir_path = os.path.join(global_engine.install_path, 'shim/executor-bash/automation/jenkins/aws')
+        assert global_engine.environment['AUTOMATION_DIR'] == automation_dir_path
+
+
+def test_installed_engine_loading():
+    '''
+    Tests that we can discover engines that have been installed
+    and that they can be discovered by the InstalledEngine basic loader
+    '''
+    with tempfile.TemporaryDirectory() as store_dir:
+        engine_store = EngineStore(store_dir=store_dir)
+
+        engine_store.engine_loaders = [
+            InstalledEngineLoader(engine_store.engine_dir)
+        ]
+
+        assert len(engine_store.engines) == 0
+
+        '''
+        Engine is created in a directory which matches the engine_store engine search location
+        The engine isn't loaded through an engine loader yet
+        '''
+        manually_installed_engine = Engine(
+            name='installed_engine',
+            description='an installed engine'
+        )
+        manually_installed_engine.engine_dir = engine_store.engine_dir
+
+        manually_installed_engine.sources = [
+            ShimPathEngineSource(
+                name='shim_source',
+                description='A basic shim engine'
+            )
+        ]
+
+        manually_installed_engine.parts = [
+            CoreEnginePart(
+                source_name='shim_source',
+                source_path=''
+            )
+        ]
+
+        manually_installed_engine.install()
+        assert os.path.isfile(manually_installed_engine.install_state_file)
+
+        '''
+        Use the Installed loader to discover the manually installed engine
+        '''
+        discovered_engine = engine_store.get_engine('installed_engine')
+        assert discovered_engine.name == 'installed_engine'
+
+        generation_engine_path = os.path.join(discovered_engine.install_path, 'shim_source')
+        assert discovered_engine.environment['GENERATION_ENGINE_DIR'] == generation_engine_path
+
+
+@mock_container_registry()
+def test_unicycle_engine_loading(mock_login_token, mock_image_manifest, mock_image_to_dir):
+    '''
+    tests that we can run source loading from a container
+    '''
+
+    with tempfile.TemporaryDirectory() as store_dir:
+        engine_store = EngineStore(store_dir=store_dir)
+
+        engine_store.engine_loaders = [
+            UnicycleEngineLoader()
+        ]
+
+        unicycle_engine = engine_store.get_engine('unicycle')
+        unicycle_engine.install()
+
+        assert unicycle_engine.name == 'unicycle'
+        assert mock_image_manifest.call_count == len(unicycle_engine.sources)
+
+        container_digests = ['config_digest[1]'] * len(unicycle_engine.sources)
+        expected_digest = 'sha256:' + hashlib.sha256(':'.join(container_digests).encode('utf-8')).hexdigest()
+        assert unicycle_engine.digest == expected_digest

--- a/hamlet-cli/tests/unit/command/engine/test_engine.py
+++ b/hamlet-cli/tests/unit/command/engine/test_engine.py
@@ -1,0 +1,130 @@
+import json
+from unittest import mock
+from click.testing import CliRunner
+
+
+from hamlet.command.engine import (
+    list_engines,
+    clean_engines,
+    install_engine,
+    set_engine,
+    env
+)
+
+
+def mock_engine(name, description, installed, digest=''):
+    mock_engine = mock.Mock()
+    mock_engine.name = name
+    mock_engine.description = description
+    mock_engine.digest = digest
+    type(mock_engine).installed = mock.PropertyMock(return_value=installed)
+
+    return mock_engine
+
+
+def mock_backend():
+    def decorator(func):
+        @mock.patch('hamlet.command.engine.engine_store')
+        def wrapper(mock_engine_store, *args, **kwargs):
+
+            mock_engines = [
+                mock_engine(
+                    name='Name[1]',
+                    description='Description[1]',
+                    installed=False
+                ),
+                mock_engine(
+                    name='Name[2]',
+                    description='Description[2]',
+                    installed=True,
+                    digest='Digest[2]'
+                )
+            ]
+
+            type(mock_engine_store).engines = mock.PropertyMock(return_value=mock_engines)
+            type(mock_engine_store).global_engine = mock.PropertyMock(return_value='Name[2]')
+
+            return func(mock_engine_store, *args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+@mock_backend()
+def test_list_engines(mock_engine_store):
+    cli = CliRunner()
+    result = cli.invoke(
+        list_engines,
+        [
+            '--output-format', 'json'
+        ]
+    )
+    print(result.exception)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    print(result)
+    assert len(result) == 2
+    assert {
+        'name': 'Name[1]',
+        'description': 'Description[1]',
+        'digest': '',
+        'installed': False,
+        'global': False,
+    } in result
+    assert {
+        'name': 'Name[2]',
+        'description': 'Description[2]',
+        'digest': 'Digest[2]',
+        'installed': True,
+        'global': True,
+    } in result
+
+
+@mock_backend()
+def test_install_engine(mock_engine_store):
+    cli = CliRunner()
+    result = cli.invoke(
+        install_engine,
+        [
+            '--name', 'engine[1]'
+        ]
+    )
+    print(result.exception)
+    assert result.exit_code == 0
+
+
+@mock_backend()
+def test_env(mock_engine_store):
+    cli = CliRunner()
+    result = cli.invoke(
+        env,
+        []
+    )
+    print(result.exception)
+    assert result.exit_code == 0
+    print(result.output)
+    assert result.output == '# run eval $(hamlet engine env) to set variables\n'
+
+
+@mock_backend()
+def test_set_engine(mock_engine_store):
+    cli = CliRunner()
+    result = cli.invoke(
+        set_engine,
+        [
+            'Name[1]'
+        ]
+    )
+    print(result.exception)
+    assert result.exit_code == 0
+
+
+@mock_backend()
+def test_clean_engines(mock_engine_store):
+    cli = CliRunner()
+    result = cli.invoke(
+        clean_engines,
+        []
+    )
+    print(result.exception)
+    assert result.exit_code == 0

--- a/hamlet-cli/tests/unit/command/engine/test_engine.py
+++ b/hamlet-cli/tests/unit/command/engine/test_engine.py
@@ -86,7 +86,7 @@ def test_install_engine(mock_engine_store):
     result = cli.invoke(
         install_engine,
         [
-            '--name', 'engine[1]'
+            'engine[1]'
         ]
     )
     print(result.exception)


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for managing hamlet engine installations through the cli. This allows for installing and setting a default engine to use along with installing and managing different engine installations 

At the core of this process is the EngineStore, which is a collection of engines that can be used by the hamlet cli and executors. 

Each Engine is made up of two components, Parts and Sources 

- Sources define external locations to retrieve the engine code from. The initial implementation supports an container registry pull which pulls the images based on the V2 docker registry API 
- Parts map the sources to defined hamlet components, these map to the different parts of hamlet that make up the overall engine and have a link to a source along with the ability to define an additional path on the source so that we can consolidate engine components together 

The cli has a collection of commands which allow for managing the active and installed engines
```
Usage: hamlet engine [OPTIONS] COMMAND [ARGS]...

  Manage the engine used by the executor

Options:
  --help  Show this message and exit.

Commands:
  clean-engines   Clean local engine store
  env             Get the environment variables for the current engine
  install-engine  Install an engine
  list-engines    Lists the available engines
  set-engine      Sets the global engine used
  ```

The *engine commands are pretty straightforward, the env command provides an exportable set of environment variables which match to the engine 

```
hamlet engine env
# run eval $(hamlet engine env) to set variables
export GENERATION_ENGINE_DIR="/home/hamlet/.hamlet/engine/engines/_global/shim/engine-core"
export GENERATION_PLUGIN_DIRS="/home/hamlet/.hamlet/engine/engines/_global/shim/engine-plugin-aws;/home/hamlet/.hamlet/engine/engines/_global/shim/engine-plugin-azure"
export GENERATION_BIN_DIR="/home/hamlet/.hamlet/engine/engines/_global/shim/engine-binary"
export GENERATION_BASE_DIR="/home/hamlet/.hamlet/engine/engines/_global/shim/executor-bash"
export GENERATION_DIR="/home/hamlet/.hamlet/engine/engines/_global/shim/executor-bash/cli"
export AUTOMATION_DIR="/home/hamlet/.hamlet/engine/engines/_global/shim/executor-bash/automation/jenkins/aws"
export AUTOMATION_BASE_DIR="/home/hamlet/.hamlet/engine/engines/_global/shim/executor-bash/automation"
```

There is a special engine called the _global engine which uses a symlink based approach to map these environment variables to different hamlet versions as required 

running `hamlet set-engine <new engine name>` will update the symlinks used and point to a new location 

When using the cli you can also use a specific engine for a command or define an engine in a profile to use different engines for different districts 

```
hamlet --engine <engine name> <my command> 
```

or add `engine: <engine name>` to your profile 

The cli will manage the installation of an engine if its not found on any hamlet call. If a global engine hasn't been defined this will be setup as well. 

if you have defined the hamlet engine environment variables they will be preferred by the cli of the ones defined by the engine configuration. This allows for local development and testing to continue 

## Motivation and Context

The main motivation here is to simplify the hamlet setup process and to make it as easy as possible to get going with hamlet. This removes the need to define any environment variables if you are just using the cli and if you want to use the other commands then the env structure allows for this 

Part of https://github.com/hamlet-io/architectural-decision-log/issues/11

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

