### PR TITLE
fix: logging during cli execptions and package deps

### DIFF
--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -43,6 +43,10 @@ setup(
         'marshmallow>=3.7.0,<4.0.0',
         'jmespath>=0.10.0<1.0.0',
         'importlib-resources>=5.1.2<6.0.0',
+
+        # cfn-lint has issues with the latest networkx
+        # Their requirements are installing the latest one
+        'networkx==2.4;python_version>="3.5"',
     ],
     include_package_data=True,
     python_requires='>=3.6',


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- adds a fix for the command runner to ensure that we collect and report outputs on exceptions. The stdout and stderr are split as its difficult to merge them. But this at least makes output visible
- fix for networkx install requirements which were breaking with changes between cfn-lint and networkx

## Motivation and Context

The main motivation for the logging updates is to make it easier to understand where something has gone wrong in hamlet without having to run alternative commands 

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

