### PR TITLE
feat: add support for engine updates

### DIFF
--- a/hamlet-cli/hamlet/backend/engine/__init__.py
+++ b/hamlet-cli/hamlet/backend/engine/__init__.py
@@ -4,7 +4,12 @@ import json
 from hamlet.backend.common.exceptions import BackendException
 
 from .common import ENGINE_STORE_DEFAULT_DIR
-from .engine_loader import GlobalEngineLoader, InstalledEngineLoader, UnicycleEngineLoader
+from .engine_loader import (
+    GlobalEngineLoader,
+    InstalledEngineLoader,
+    UnicycleEngineLoader,
+    TramEngineLoader
+)
 
 
 class EngineStore():
@@ -29,6 +34,7 @@ class EngineStore():
             InstalledEngineLoader(engine_dir=self.engine_dir),
             GlobalEngineLoader(),
             UnicycleEngineLoader(),
+            TramEngineLoader()
         ]
 
     @property

--- a/hamlet-cli/hamlet/backend/engine/common.py
+++ b/hamlet-cli/hamlet/backend/engine/common.py
@@ -4,5 +4,5 @@ from hamlet.env import HAMLET_HOME_DIR
 
 ENGINE_STORE_DEFAULT_DIR = os.path.join(HAMLET_HOME_DIR, 'engine')
 ENGINE_GLOBAL_NAME = '_global'
-ENGINE_DEFAULT_GLOBAL_ENGINE = 'unicycle'
+ENGINE_DEFAULT_GLOBAL_ENGINE = 'tram'
 ENGINE_STATE_FILE_NAME = 'engine_state.json'

--- a/hamlet-cli/hamlet/backend/engine/engine.py
+++ b/hamlet-cli/hamlet/backend/engine/engine.py
@@ -139,6 +139,20 @@ class EngineInterface(ABC):
         return self.install_state.get('digest', None)
 
     @property
+    def source_digest(self):
+        '''
+        return the digest of the engine sources
+        '''
+        return self._format_engine_digest(self._get_source_digests().values())
+
+    @property
+    def up_to_date(self):
+        '''
+        Is an update available for the engine
+        '''
+        return self.digest == self.source_digest
+
+    @property
     def parts(self):
         '''
         Parts link concrete hamlet components to sources

--- a/hamlet-cli/hamlet/backend/engine/engine_loader.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_loader.py
@@ -172,7 +172,56 @@ class UnicycleEngineLoader(EngineLoader):
 
         engine = Engine(
             name='unicycle',
-            description='Latest build of the official components'
+            description='Latest build of the official engine parts'
+        )
+        engine.parts = engine_parts
+        engine.sources = engine_sources
+
+        self._engines = [engine]
+
+
+class TramEngineLoader(EngineLoader):
+    '''
+    Provides the nightly build of the hamlet base engine image
+    This image is tested across all parts and sources as a collection
+    Includes testing of system level actions
+    '''
+
+    def __init__(self):
+        super().__init__()
+
+        engine_sources = [
+            ContainerEngineSource(
+                name='hamlet-engine-base',
+                description='hamlet official engine source',
+                registry_url='https://ghcr.io',
+                repository='hamlet-io/hamlet-engine-base',
+                tag='nightly'
+            ),
+        ]
+
+        engine_parts = [
+            CoreEnginePart(
+                source_path='engine/',
+                source_name='hamlet-engine-base'
+            ),
+            BashExecutorEnginePart(
+                source_path='executor-bash/',
+                source_name='hamlet-engine-base'
+            ),
+            AWSEnginePluginPart(
+                source_path='engine-plugin-aws/',
+                source_name='hamlet-engine-base'
+            ),
+            AzureEnginePluginPart(
+                source_path='engine-plugin-azure/',
+                source_name='hamlet-engine-base'
+            ),
+        ]
+
+        engine = Engine(
+            name='tram',
+            description='Nightly build of the official engine'
         )
         engine.parts = engine_parts
         engine.sources = engine_sources

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -1,11 +1,15 @@
 import click
+import os
 
 from hamlet.command.common import decorators
 from hamlet.command.common.exceptions import backend_handler
 
 from hamlet.utils import isWriteable
 from hamlet.env import HAMLET_HOME_DIR
-from hamlet.command.common.setup import setup_initial_engines
+from hamlet.command.common.engine_setup import (
+    setup_initial_engines,
+    update_engine
+)
 
 
 @click.group('root')
@@ -20,6 +24,11 @@ def root(ctx, opts):
     '''
     hamlet deploy
     '''
+
+    try:
+        os.makedirs(HAMLET_HOME_DIR, exist_ok=True)
+    except OSError:
+        pass
 
     if not isWriteable(HAMLET_HOME_DIR):
         click.echo(
@@ -38,3 +47,4 @@ def root(ctx, opts):
 
     if isWriteable(HAMLET_HOME_DIR):
         setup_initial_engines(opts.engine)
+        update_engine(opts.engine, opts.auto_update_engine)

--- a/hamlet-cli/hamlet/command/common/config.py
+++ b/hamlet-cli/hamlet/command/common/config.py
@@ -49,6 +49,7 @@ class ConfigSchema(object):
         environment = ConfigParam(name='environment', type=str)
         segment = ConfigParam(name='segment', type=str)
         engine = ConfigParam(name='engine', type=str)
+        auto_update_engine = ConfigParam(name='auto_update_engine', type=bool)
 
     @matches_section("profile:*")
     class Profile(Default):
@@ -225,6 +226,16 @@ class Options:
     def engine(self, value):
         '''Set the engine setting'''
         self._set_option('engine', value)
+
+    @property
+    def auto_update_engine(self):
+        '''Set engine automatic updating'''
+        return self._get_option('auto_update_engine')
+
+    @auto_update_engine.setter
+    def auto_update_engine(self, value):
+        '''Set the auto_update_engine setting'''
+        self._set_option('auto_update_engine', value)
 
     @property
     def generation_framework(self):

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -80,6 +80,12 @@ def common_engine_options(func):
         envvar='HAMLET_ENGINE',
         help='The name of the engine to use',
     )
+    @click.option(
+        '--auto-update-engine/--no-auto-update-engine',
+        envvar='HAMLET_ENGINE_UPDATE',
+        default=True,
+        help='Automatically update engines'
+    )
     @click.pass_context
     @functools.wraps(func)
     def wrapper(ctx, *args, **kwargs):
@@ -88,6 +94,7 @@ def common_engine_options(func):
         '''
         opts = ctx.ensure_object(Options)
         opts.engine = kwargs.pop('engine')
+        opts.auto_update_engine = kwargs.pop('auto_update_engine')
         kwargs['opts'] = opts
         return ctx.invoke(func, *args, **kwargs)
 

--- a/hamlet-cli/hamlet/command/common/decorators.py
+++ b/hamlet-cli/hamlet/command/common/decorators.py
@@ -82,7 +82,7 @@ def common_engine_options(func):
     )
     @click.option(
         '--auto-update-engine/--no-auto-update-engine',
-        envvar='HAMLET_ENGINE_UPDATE',
+        envvar='HAMLET_UPDATE_ENGINE',
         default=True,
         help='Automatically update engines'
     )

--- a/hamlet-cli/hamlet/command/common/engine_setup.py
+++ b/hamlet-cli/hamlet/command/common/engine_setup.py
@@ -39,3 +39,28 @@ def setup_initial_engines(engine_override):
         set_engine_env(global_engine.environment)
     else:
         set_engine_env(engine.environment)
+
+
+def update_engine(engine_override, auto_install):
+    '''
+    Automatically update the configured engine
+    '''
+    engine_name = engine_store.global_engine if engine_override is None else engine_override
+    engine = engine_store.get_engine(engine_name)
+
+    if not engine.up_to_date:
+        if auto_install:
+            click.echo(
+                click.style(f'[*] update available for {engine_name} - installing update', fg='yellow')
+            )
+            engine.install()
+        else:
+            click.echo(
+                click.style(
+                    (
+                        f'[*] update available for {engine_name}'
+                        '- run hamlet engine install-engine {engine_name} to update'
+                    ),
+                    fg='yellow'
+                )
+            )

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -21,11 +21,12 @@ def engines_table(data):
                 wrap_text(row['description']),
                 wrap_text(row['installed']),
                 wrap_text(row['global']),
+                wrap_text(row['update_available']),
             ]
         )
     return tabulate(
         tablerows,
-        headers=['Name', 'Description', 'Installed', 'GlobalEngine'],
+        headers=['Name', 'Description', 'Installed', 'Global', 'Update Available'],
         tablefmt='github'
     )
 
@@ -53,13 +54,22 @@ def list_engines():
     data = []
 
     for engine in engine_store.engines:
+
+        update_available = None
+        if engine.installed:
+            if engine.up_to_date:
+                update_available = False
+            else:
+                update_available = True
+
         data.append(
             {
                 'name': engine.name,
                 'description': engine.description,
                 'installed': engine.installed,
                 'digest': engine.digest,
-                'global': True if engine.name == engine_store.global_engine else False
+                'global': True if engine.name == engine_store.global_engine else False,
+                'update_available': update_available
             }
         )
     return data

--- a/hamlet-cli/tests/unit/command/engine/test_engine.py
+++ b/hamlet-cli/tests/unit/command/engine/test_engine.py
@@ -70,6 +70,7 @@ def test_list_engines(mock_engine_store):
         'digest': '',
         'installed': False,
         'global': False,
+        'update_available': None
     } in result
     assert {
         'name': 'Name[2]',
@@ -77,6 +78,7 @@ def test_list_engines(mock_engine_store):
         'digest': 'Digest[2]',
         'installed': True,
         'global': True,
+        'update_available': False
     } in result
 
 


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for detecting and install updates to engines. By default the cli will check for updates on each command 
run and install the update or warn that one is available for the currently selected engine.
- Adds a check in hamlet engine list-engines to show available updates
- Disabling auto update is available through the root command, env varor profile. env var = HAMLET_UPDATE_ENGINE, and auto-update-engine isavailable for the profile and cli
- Adds the tram engine loader which is a tested nightly build of the offical hamlet components
- Fixes an issue where the hamlet home dir didn't exist when installing engines

## Motivation and Context

The main motivation for this feature is to allow users to see if a new hamlet engine is available and have it automatically installed. This is useful on the continuous build tags ( unicycle and tram ) which update on a regular basis and are generally used on deployments that are using the latest features

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes

Part of https://github.com/hamlet-io/architectural-decision-log/issues/11

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

