### PR TITLE
feat: include cli version in command

### DIFF
--- a/hamlet-cli/.bumpversion.cfg
+++ b/hamlet-cli/.bumpversion.cfg
@@ -3,17 +3,16 @@ current_version = 8.2.0-dev12
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 
-[bumpversion:file:setup.py]
-
+[bumpversion:file:hamlet/__about__.py]
 [bumpversion:file:]

--- a/hamlet-cli/hamlet/__about__.py
+++ b/hamlet-cli/hamlet/__about__.py
@@ -1,0 +1,33 @@
+import os.path
+
+
+__all__ = [
+    '__title__',
+    '__summary__',
+    '__uri__',
+    '__version__',
+    '__commit__',
+    '__author__',
+    '__email__',
+]
+
+
+try:
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    base_dir = None
+
+__title__ = 'hamlet'
+__summary__ = 'Building your infrastructure'
+__url__ = "https://hamlet.io"
+
+__version__= '8.2.0-dev12'
+
+if base_dir is not None and os.path.exists(os.path.join(base_dir, ".commit")):
+    with open(os.path.join(base_dir, ".commit")) as fp:
+        __commit__ = fp.read().strip()
+else:
+    __commit__ = None
+
+__author__ = 'Hamlet'
+__email__ = 'help@hamlet.io'

--- a/hamlet-cli/hamlet/command/__init__.py
+++ b/hamlet-cli/hamlet/command/__init__.py
@@ -1,6 +1,8 @@
 import click
 import os
 
+from hamlet import __about__
+
 from hamlet.command.common import decorators
 from hamlet.command.common.exceptions import backend_handler
 
@@ -13,6 +15,7 @@ from hamlet.command.common.engine_setup import (
 
 
 @click.group('root')
+@click.version_option(__about__.__version__)
 @decorators.common_engine_options
 @decorators.common_district_options
 @decorators.common_cli_config_options

--- a/hamlet-cli/setup.py
+++ b/hamlet-cli/setup.py
@@ -5,6 +5,10 @@ from setuptools.command.install import install
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+version = {}
+with open("hamlet/__about__.py", 'r') as fp:
+    exec(fp.read(), version)
+
 packages = find_packages(exclude=["tests.*", "tests"])
 
 
@@ -23,10 +27,10 @@ class InstallCommand(install):
 
 
 setup(
-    name='hamlet-cli',
-    version='8.2.0-dev12',
-    author='Hamlet',
-    url="https://github.com/hamlet-io/executor-python",
+    name=version['__title__'],
+    version=version['__version__'],
+    author=version['__author__'],
+    url=version['__url__'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=packages,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the --version flag to the root hamlet command which shows the current running version of the hamlet cli
- Moves the version details to a file which can be imported into other modules

Pretty straightforward at the moment 

```
hamlet --version 
hamlet, version 8.2.0-dev12
```

## Motivation and Context

Fixes #158  to allow for debugging and troubleshooting across different installations 

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

