### PR TITLE
fix: options passed to backend query for diagrams

### DIFF
--- a/hamlet-cli/hamlet/command/visual/__init__.py
+++ b/hamlet-cli/hamlet/command/visual/__init__.py
@@ -24,11 +24,9 @@ LIST_DIAGRAMS_QUERY = (
 )
 
 
-def find_diagrams_from_options(generation, ids):
+def find_diagrams_from_options(options, ids):
     query_args = {
-        'generation_provider': generation.generation_provider,
-        'generation_framework': generation.generation_framework,
-        'generation_input_source': generation.generation_input_source,
+        **options.opts,
         'generation_entrance': 'diagraminfo',
         'output_filename': 'diagraminfo.json',
         'use_cache': False


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

provides the full options stack to the query used to find diagrams instead of the older generation context

## Motivation and Context

Diagram listing would fail if the account was set through the hamlet cli options

## How Has This Been Tested?

tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

