### PR TITLE
feat: detailed engine information

### DIFF
--- a/hamlet-cli/hamlet/__about__.py
+++ b/hamlet-cli/hamlet/__about__.py
@@ -4,7 +4,7 @@ import os.path
 __all__ = [
     '__title__',
     '__summary__',
-    '__uri__',
+    '__url__',
     '__version__',
     '__commit__',
     '__author__',
@@ -21,7 +21,7 @@ __title__ = 'hamlet-cli'
 __summary__ = 'Building your infrastructure'
 __url__ = "https://hamlet.io"
 
-__version__= '8.2.0-dev14'
+__version__ = '8.2.0-dev14'
 
 if base_dir is not None and os.path.exists(os.path.join(base_dir, ".commit")):
     with open(os.path.join(base_dir, ".commit")) as fp:

--- a/hamlet-cli/hamlet/backend/engine/engine_source.py
+++ b/hamlet-cli/hamlet/backend/engine/engine_source.py
@@ -132,7 +132,7 @@ class ContainerEngineSource(EngineSourceInterface):
     def build_details(self):
         if self._dst_dir is not None:
             engine_source_files = glob.glob(
-                os.path.join(self.dst_dir, '**/.hamlet/engine_source.json'),
+                os.path.join(self._dst_dir, '**/.hamlet/engine_source.json'),
                 recursive=True
             )
 

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -87,15 +87,23 @@ def list_engines():
 @click.option(
     '-n',
     '--name',
-    required=True,
-    help='The name of the engine to describe'
+    help='An override to the default engine name to query'
 )
 @exceptions.backend_handler()
-def describe_engine(name):
+@config.pass_options
+def describe_engine(opts, name):
     '''
     Provides a detailed description of an engine
     '''
-    engine = engine_store.get_engine(name)
+    if name:
+        engine_name = name
+    elif opts.engine:
+        engine_name = opts.engine
+    else:
+        engine_name = engine_store.global_engine
+
+    engine = engine_store.get_engine(engine_name)
+
     engine_details = {
         'engine': {
             'name': engine.name,

--- a/hamlet-cli/hamlet/command/engine/__init__.py
+++ b/hamlet-cli/hamlet/command/engine/__init__.py
@@ -1,15 +1,17 @@
 import click
 import os
 import shutil
+import json
 
 from tabulate import tabulate
 
 from hamlet.command import root as cli
 from hamlet.command.common import exceptions, config
+from hamlet.command.common.display import json_or_table_option, wrap_text
 
 from hamlet.backend.engine import engine_store
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
-from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.backend.engine.engine_source import EngineSourceBuildData
 
 
 def engines_table(data):
@@ -76,6 +78,68 @@ def list_engines():
 
 
 @group.command(
+    'describe-engine',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.option(
+    '-n',
+    '--name',
+    required=True,
+    help='The name of the engine to describe'
+)
+@exceptions.backend_handler()
+def describe_engine(name):
+    '''
+    Provides a detailed description of an engine
+    '''
+    engine = engine_store.get_engine(name)
+    engine_details = {
+        'engine': {
+            'name': engine.name,
+            'description': engine.description,
+            'hidden': engine.hidden,
+            'installed': engine.installed,
+            'engine_dir': engine.engine_dir,
+            'up_to_date': engine.up_to_date,
+            'current_digest': engine.digest,
+            'latest_digest': engine.source_digest
+        },
+        'environment': engine.environment
+    }
+
+    sources = []
+    for source in engine.sources:
+        sources.append(
+            {
+                'name': source.name,
+                'description': source.description,
+                'latest_digest': source.digest,
+                'build_details': source.build_details,
+                'package_details': source.package_details
+            }
+        )
+
+    parts = []
+    for part in engine.parts:
+        parts.append(
+            {
+                'type': part.type,
+                'description': part.description,
+                'source_path': part.source_path,
+                'source_name': part.source_name
+            }
+        )
+
+    engine_details['sources'] = sources
+    engine_details['parts'] = parts
+
+    click.echo(json.dumps(engine_details, indent=2))
+
+
+@group.command(
     'clean-engines',
     short_help='',
     context_settings=dict(
@@ -139,7 +203,13 @@ def set_engine(name):
     engine_store.global_engine = name
 
 
-@group.command('env')
+@group.command(
+    'env',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
 @click.argument(
     'environment_variable',
     required=False,
@@ -167,3 +237,39 @@ def env(opts, environment_variable):
             click.echo(engine.environment[environment_variable])
         except KeyError:
             click.echo('')
+
+
+@group.command(
+    'add-engine-source-build',
+    short_help='',
+    context_settings=dict(
+        max_content_width=240
+    )
+)
+@click.option(
+    '-p',
+    '--path',
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        resolve_path=True
+    ),
+    default='.',
+    help='The path to generate build details for'
+)
+@exceptions.backend_handler()
+def add_engine_source_build(path):
+    """
+    Generates build metadata that will be used by the engine cli
+    """
+    build_details = EngineSourceBuildData(path=path)
+
+    hamlet_meta_dir = os.path.join(path, '.hamlet')
+    hamlet_build_state_file = os.path.join(hamlet_meta_dir, 'engine_source.json')
+    if not os.path.isdir(hamlet_meta_dir):
+        os.makedirs(hamlet_meta_dir)
+
+    with open(hamlet_build_state_file, 'w') as file:
+        json.dump(build_details.details, file, indent=2)

--- a/hamlet-cli/tests/unit/command/engine/test_engine.py
+++ b/hamlet-cli/tests/unit/command/engine/test_engine.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 
 from hamlet.command.engine import (
     list_engines,
+    describe_engine,
     clean_engines,
     install_engine,
     set_engine,
@@ -80,6 +81,20 @@ def test_list_engines(mock_engine_store):
         'global': True,
         'update_available': False
     } in result
+
+
+@mock.patch("json.dumps", mock.MagicMock(return_value='{cool}'))
+@mock_backend()
+def test_describe_engine(mock_engine_store):
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_engine,
+        [
+            '--name', 'Name[1]'
+        ]
+    )
+    print(result.output)
+    assert result.exit_code == 0
 
 
 @mock_backend()


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds two new commands to the engine command group 

- describe-engine - provides a detailed description of an engine including its current state and the state of the parts and sources that make up the engine 
- add-engine-source-build - Is used to create a hamlet_source.json file which locates key details about how the code of a repo was built that will be used as a source. This is intended to be run as part of the build of engine sources so that we can query them to find out where the code came from 

## Motivation and Context

The describe engine command allows for detailed information when troubleshooting issues and allows people to see what engine sources are currently being used.

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

