### PR TITLE
fix: handle  installation process and global env

### DIFF
--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -1,44 +1,53 @@
 import click
+from hamlet.backend import engine
 
 from hamlet.backend.engine import engine_store
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME, ENGINE_DEFAULT_GLOBAL_ENGINE
 from hamlet.env import set_engine_env
 
 
-def setup_initial_engines(engine_override):
+def setup_global_engine():
     '''
-    Sets up the initial engines for the cli to start working
+    Always make sure the global engine is installed
     '''
-    use_global_env = False
-
     global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
     if not global_engine.installed:
         global_engine.install()
 
+
+def get_engine_env(engine_override):
+
     if engine_override is not None:
         engine = engine_store.get_engine(engine_override)
     else:
-        engine = engine_store.get_engine(ENGINE_DEFAULT_GLOBAL_ENGINE)
-        use_global_env = True
+        engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
 
-    if not engine.installed:
-        click.echo(
-            click.style(f'[*] No default engine found installing default engine - {engine.name}', fg='yellow'),
-            err=True
-        )
-        engine.install()
+    set_engine_env(engine.environment)
 
+
+def setup_initial_engines(engine_override):
+    '''
+    Sets up the initial engines for the cli to start working
+    '''
     if engine_store.global_engine is None:
+
+        if engine_override is not None:
+            engine = engine_store.get_engine(engine_override)
+        else:
+            engine = engine_store.get_engine(ENGINE_DEFAULT_GLOBAL_ENGINE)
+
+        if not engine.installed:
+            click.echo(
+                click.style(f'[*] No default engine found installing default engine - {engine.name}', fg='yellow'),
+                err=True
+            )
+            engine.install()
+
         click.echo(
             click.style(f'[*] Setting the global engine to the default engine - {engine.name}', fg='yellow'),
             err=True
         )
-        engine_store.global_engine = ENGINE_DEFAULT_GLOBAL_ENGINE
-
-    if use_global_env:
-        set_engine_env(global_engine.environment)
-    else:
-        set_engine_env(engine.environment)
+        engine_store.global_engine = engine.name
 
 
 def check_engine_update(engine_override):

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -35,9 +35,9 @@ def engines_table(data):
 
 @cli.group('engine')
 def group():
-    """
+    '''
     Manage the engine used by the executor
-    """
+    '''
 
 
 @group.command(
@@ -184,6 +184,7 @@ def clean_engines():
     Clean local engine store
     '''
 
+    click.echo(f'[*] cleaning engines in {engine_store.store_dir}')
     if os.path.isdir(engine_store.store_dir):
         shutil.rmtree(engine_store.store_dir)
 
@@ -229,9 +230,10 @@ def set_engine(name):
     engine = engine_store.get_engine(name)
 
     if not engine.installed:
+        click.echo(f'[*] installing engine')
         engine.install()
 
-    click.echo(f'default engine set to {name}')
+    click.echo(f'[*] global engine set to {name}')
     engine_store.global_engine = name
 
 
@@ -250,9 +252,9 @@ def set_engine(name):
 @exceptions.backend_handler()
 @config.pass_options
 def env(opts, environment_variable):
-    """
+    '''
     Get the environment variables for the current engine
-    """
+    '''
 
     if opts.engine is None:
         engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
@@ -293,9 +295,10 @@ def env(opts, environment_variable):
 )
 @exceptions.backend_handler()
 def add_engine_source_build(path):
-    """
-    Generates build metadata that will be used by the engine cli
-    """
+    '''
+    Generates build metadata for engine sources
+    '''
+
     build_details = EngineCodeSourceBuildData(path=path)
 
     hamlet_meta_dir = os.path.join(path, '.hamlet')


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- always install the global engine regardless of auto update process
- only run auto engine installs when not in the engine subcommand
- always set the engine env
- add some extra echos for user info

## Motivation and Context

fixes #175  and makes sure the global engine is always available for explicit set commands run at the start of a hamlet session

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

