### PR TITLE
feat: handle out of date global engine

### DIFF
--- a/hamlet/backend/engine/__init__.py
+++ b/hamlet/backend/engine/__init__.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import json
 
 from hamlet.backend.common.exceptions import BackendException
@@ -120,6 +121,14 @@ class EngineStore():
 
             with open(self._store_state_file, 'w') as file:
                 json.dump(self.store_state, file)
+
+    def clean_engines(self):
+        if os.path.isdir(os.path.join(self.engine_dir)):
+            shutil.rmtree(self.engine_dir)
+
+    def clean_engine(self, name):
+        if os.path.isdir(os.path.join(self.engine_dir, name)):
+            shutil.rmtree(os.path.join(self.engine_dir, name))
 
 
 engine_store = EngineStore(store_dir=ENGINE_STORE_DEFAULT_DIR)

--- a/hamlet/backend/engine/engine_loader.py
+++ b/hamlet/backend/engine/engine_loader.py
@@ -104,14 +104,13 @@ class InstalledEngineLoader(EngineLoader):
                                         engine_states.append(json.load(f))
 
         for engine_state in engine_states:
-
-            if engine_state.get('version', '0.0.0') == ENGINE_STATE_VERSION:
-                yield InstalledEngine(
-                    name=engine_state['name'],
-                    description=engine_state['description'],
-                    digest=engine_state['install']['digest'],
-                    hidden=engine_state['hidden'],
-                )
+            yield InstalledEngine(
+                name=engine_state['name'],
+                description=engine_state['description'],
+                digest=engine_state['install']['digest'],
+                hidden=engine_state['hidden'],
+                state_version=engine_state.get('version', '0.0.0')
+            )
 
 
 class UnicycleEngineLoader(EngineLoader):

--- a/hamlet/backend/engine/exceptions.py
+++ b/hamlet/backend/engine/exceptions.py
@@ -1,0 +1,16 @@
+
+
+from hamlet.backend.common.exceptions import BackendException
+
+
+class HamletEngineInvalidVersion(BackendException):
+    '''
+    Raise when the engine found in state does not align with the version the cli supports
+    '''
+
+    def __init__(self, engine_name, version):
+        self.version = version
+        self.engine_name = engine_name
+
+        msg = f'Engine {self.engine_name} state not supported by this cli version - run: hamlet engine install-engine {self.engine_name}'
+        super().__init__(msg)

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -3,6 +3,7 @@ import os
 
 from hamlet.command.common import decorators
 from hamlet.command.common.exceptions import backend_handler
+from hamlet.backend.engine.exceptions import HamletEngineInvalidVersion
 
 from hamlet.utils import isWriteable
 from hamlet.env import HAMLET_HOME_DIR
@@ -54,8 +55,12 @@ def root(ctx, opts):
         )
 
     if homeWritable:
-        setup_global_engine()
-        get_engine_env(opts.engine)
+
+        try:
+            setup_global_engine()
+            get_engine_env(opts.engine)
+        except HamletEngineInvalidVersion:
+            pass
 
         if ctx.invoked_subcommand != 'engine':
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

- add support for reinstalling the global engine if it is not the same state version as the one expected by the cli
- add new exception case so that we can handle invalid engines
- add warning that you might loose an old engine if it can't be found after being cleaned
- moves clean functions to the engine_store for wider usage across engine handling

## Motivation and Context

The main motivation here is to make it easy to manage engine versions and allow for the cli to handle as much of the version management for engines possible without requiring too much effort. 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

