### PR TITLE
refactor: remove networkx fixed dependecy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'cookiecutter>=1.7.0,<2.0.0',
         'tabulate>=0.8.0,<1.0.0',
         'Jinja2>=2.11.0,<3.0.0',
-        'cfn-lint>=0.25.0,<1.0.0',
+        'cfn-lint>=0.51.0,<1.0.0',
         'cfn-flip>=1.2.0,<2.0.0',
         'diagrams>=0.18.0,<1.0.0',
         'marshmallow>=3.7.0,<4.0.0',
@@ -63,10 +63,6 @@ setup(
         'importlib-resources>=5.2.0<6.0.0',
         'www-authenticate>=0.9.2<1.0.0',
         'requests>=2.25.1<3.0.0',
-
-        # cfn-lint has issues with the latest networkx
-        # Their requirements are installing the latest one
-        'networkx==2.4;python_version>="3.5"',
     ],
     include_package_data=True,
     python_requires='>=3.6',


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

removes an unrequired dependency on networkx which is used by cfn-lint and another package. This was causing issues on import that have been fixed in version 0.25.0 of the cli

## Motivation and Context

removes fixed dependency that we didn't need

## How Has This Been Tested?

tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

