### PR TITLE
feat(engine): add the wrapper into the tram

### DIFF
--- a/hamlet/backend/engine/engine_loader.py
+++ b/hamlet/backend/engine/engine_loader.py
@@ -213,6 +213,10 @@ class TramEngineLoader(EngineLoader):
         ]
 
         engine_parts = [
+            WrapperEnginePart(
+                source_path='engine-core/',
+                source_name='hamlet-engine-base'
+            ),
             CoreEnginePart(
                 source_path='engine/',
                 source_name='hamlet-engine-base'


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

adds the wrapper engine part into the tram engine definition. Now that the wrapper has been included in the unicycle release its available for use in the tram releases

## Motivation and Context

Adding the wrapper means that both our stable and unstable engines use the dedicated package for the wrapper instead of relying on one in the source code

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

