### PR TITLE
feat: container tags and repository refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'jmespath>=0.10.0<1.0.0',
         'importlib-resources>=5.2.0<6.0.0',
         'www-authenticate>=0.9.2<1.0.0',
-        'requests>=2.25.1<3.0.0',
+        'httpx>=0.18.2<1.0.0',
     ],
     include_package_data=True,
     python_requires='>=3.6',


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- replaces requests with httpx which is the successor to requests
- refactors the container repository process into a self contained class
which manages detailing with container registries
- Adds support for getting the tags of a container repository

## Motivation and Context

The main motivation was to separate dealing with the container registry from the container source and to use clients to increase network performance and authentication handling 
Adding tag returns allows us to add multiple engines for tags available on a container

## How Has This Been Tested?

Tested locally and with testing suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

