### PR TITLE
feat: hidden engines and dynamic loaders

### DIFF
--- a/hamlet/backend/deploy/__init__.py
+++ b/hamlet/backend/deploy/__init__.py
@@ -79,7 +79,6 @@ def create_deployment(
     create_template_backend.run(**generate_args, _is_cli=_is_cli)
 
 
-
 def run_deployment(
         deployment_provider,
         deployment_group,

--- a/hamlet/backend/engine/__init__.py
+++ b/hamlet/backend/engine/__init__.py
@@ -9,7 +9,10 @@ from .engine_loader import (
     GlobalEngineLoader,
     InstalledEngineLoader,
     UnicycleEngineLoader,
-    TramEngineLoader
+    LatestTramEngineLoader,
+    TramEngineLoader,
+    LatestTrainEngineLoader,
+    TrainEngineLoader
 )
 
 
@@ -35,7 +38,10 @@ class EngineStore():
             InstalledEngineLoader(engine_dir=self.engine_dir),
             GlobalEngineLoader(),
             UnicycleEngineLoader(),
-            TramEngineLoader()
+            LatestTramEngineLoader(),
+            TramEngineLoader(),
+            LatestTrainEngineLoader(),
+            TrainEngineLoader(),
         ]
 
     @property
@@ -44,7 +50,7 @@ class EngineStore():
         Return the engines that have been loaded into the store
         '''
         self._load_engines()
-        return list(filter(lambda x: not x.hidden, self._engines.values()))
+        return list(self._engines.values())
 
     @property
     def global_engine(self):

--- a/hamlet/backend/engine/engine.py
+++ b/hamlet/backend/engine/engine.py
@@ -21,7 +21,7 @@ class EngineInterface(ABC):
         self.description = description
         self.hidden = hidden
 
-        self.update_timeout=update_timeout
+        self.update_timeout = update_timeout
 
         self._engine_state_filename = ENGINE_STATE_FILE_NAME
 
@@ -147,19 +147,18 @@ class EngineInterface(ABC):
 
         install_state = {
             'part_paths': self._get_part_paths(),
-            'digest' : self._format_engine_digest(source_digests),
-            'source_install_state' : [ vars(s) for s in source_install_state]
+            'digest': self._format_engine_digest(source_digests),
+            'source_install_state': [vars(s) for s in source_install_state]
         }
 
         self._engine_state['version'] = ENGINE_STATE_VERSION
         self._engine_state['install'] = install_state
         self._save_engine_state()
 
-
     def _update_updater_state(self):
         updater_state = {
             'last_check': datetime.now().isoformat(timespec='seconds'),
-            'latest_digest': self._format_engine_digest([ s.digest for s in self.sources])
+            'latest_digest': self._format_engine_digest([s.digest for s in self.sources])
         }
         self._engine_state['updater'] = updater_state
         self._save_engine_state()
@@ -180,7 +179,9 @@ class EngineInterface(ABC):
         '''
         if self.installed:
             if self.updater_state is not None:
-                if (datetime.now() - datetime.strptime(self.updater_state['last_check'], "%Y-%m-%dT%H:%M:%S")).seconds > self.update_timeout:
+                if (datetime.now()
+                        - datetime.strptime(
+                            self.updater_state['last_check'], "%Y-%m-%dT%H:%M:%S")).seconds > self.update_timeout:
                     self._update_updater_state()
 
                 if ignore_cache:
@@ -191,7 +192,6 @@ class EngineInterface(ABC):
 
             self._load_engine_state()
             return self.updater_state.get('latest_digest', None)
-
 
     def up_to_date(self, ignore_cache=False):
         '''

--- a/hamlet/backend/engine/engine_code_source.py
+++ b/hamlet/backend/engine/engine_code_source.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
 
+
 class EngineCodeSourceBuildData():
     '''
     Provides utility functions that generate version details about

--- a/hamlet/backend/engine/engine_source.py
+++ b/hamlet/backend/engine/engine_source.py
@@ -108,11 +108,13 @@ class ContainerEngineSource(EngineSourceInterface):
             build_sources = {}
             for engine_source_path in engine_source_paths:
                 with open(engine_source_path, 'r') as file:
-                    source_name = str(engine_source_path)[len((os.path.commonprefix([dst_dir, engine_source_path]))):len(engine_source)]
+                    source_name = str(engine_source_path)[
+                        len(dst_dir)
+                        :len(str(engine_source_path)) - len(engine_source)
+                    ]
                     build_sources[source_name] = json.load(file)
 
             return build_sources
-
 
 
 class EngineSourcePullState(dict):

--- a/hamlet/backend/engine/exceptions.py
+++ b/hamlet/backend/engine/exceptions.py
@@ -12,5 +12,8 @@ class HamletEngineInvalidVersion(BackendException):
         self.version = version
         self.engine_name = engine_name
 
-        msg = f'Engine {self.engine_name} state not supported by this cli version - run: hamlet engine install-engine {self.engine_name}'
+        msg = (
+            f'Engine {self.engine_name} state not supported by this cli version'
+            f'- run: hamlet engine install-engine {self.engine_name}'
+        )
         super().__init__(msg)

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -90,7 +90,7 @@ def check_engine_update(engine_override):
             click.style(
                 (
                     f'[!] engine update check failed for {engine_name}\n'
-                     '[!]   - run hamlet engine list-engines for more details'
+                    '[!]   - run hamlet engine list-engines for more details'
                 ),
                 fg='red'
             )

--- a/hamlet/command/deploy/run.py
+++ b/hamlet/command/deploy/run.py
@@ -116,11 +116,10 @@ def run_deployments(
             if deployment_state != 'orphaned':
                 create_deployment(deployment_group, deployment_unit, deployment_mode, output_dir, **options.opts)
 
-
         for operation in deployment['Operations']:
 
             if dryrun:
-                run_deployment(provider, deployment_group, deployment_unit, operation, output_dir, dryrun )
+                run_deployment(provider, deployment_group, deployment_unit, operation, output_dir, dryrun)
 
             if (
                 (confirm and click.confirm(f'Start Deployment of {deployment_group}/{deployment_unit} ?'))

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -63,7 +63,7 @@ def list_engines(show_hidden):
     for engine in engine_store.engines:
 
         update_available = None
-        if ( show_hidden and engine.hidden ) or not engine.hidden:
+        if (show_hidden and engine.hidden) or not engine.hidden:
             if engine.installed:
                 try:
                     if engine.up_to_date(ignore_cache=True):
@@ -137,7 +137,7 @@ def describe_engine(opts, name):
             'latest_digest': latest_digest
         },
         'environment': engine.environment,
-        'install_state' : engine.install_state
+        'install_state': engine.install_state
     }
 
     sources = []
@@ -235,7 +235,8 @@ def install_engine(name, force):
         if force or click.confirm(
                 (
                     '[!] The engine state of this engine is not compatible the cli\n'
-                    '[!] To fix this we need to reinstall the engine, if the engine can not be reinstalled it will no longer be available\n'
+                    '[!] To fix this we need to reinstall the engine,'
+                    'if the engine can not be reinstalled it will no longer be available\n'
                     '[!] Is this ok?'
                 ), abort=True):
             engine_store.clean_engine(name)
@@ -266,7 +267,7 @@ def set_engine(name):
     engine = engine_store.get_engine(name)
 
     if not engine.installed:
-        click.echo(f'[*] installing engine')
+        click.echo('[*] installing engine')
         engine.install()
 
     click.echo(f'[*] global engine set to {name}')

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -1,6 +1,5 @@
 import click
 import os
-import shutil
 import json
 
 from tabulate import tabulate
@@ -48,9 +47,14 @@ def group():
         max_content_width=240
     )
 )
+@click.option(
+    '--show-hidden/--hide-hidden',
+    default=False,
+    help='Control visibility of hidden engines'
+)
 @json_or_table_option(engines_table)
 @exceptions.backend_handler()
-def list_engines():
+def list_engines(show_hidden):
     '''
     Lists the available engines
     '''
@@ -59,26 +63,27 @@ def list_engines():
     for engine in engine_store.engines:
 
         update_available = None
-        if engine.installed:
-            try:
-                if engine.up_to_date(ignore_cache=True):
-                    update_available = False
-                else:
-                    update_available = True
-            except BaseException as e:
-                click.secho(f'[!]engine update failed for {engine.name}', fg='red', err=True)
-                click.secho(f'[!]  {e}', fg='red', err=True)
+        if ( show_hidden and engine.hidden ) or not engine.hidden:
+            if engine.installed:
+                try:
+                    if engine.up_to_date(ignore_cache=True):
+                        update_available = False
+                    else:
+                        update_available = True
+                except BaseException as e:
+                    click.secho(f'[!]engine update failed for {engine.name}', fg='red', err=True)
+                    click.secho(f'[!]  {e}', fg='red', err=True)
 
-        data.append(
-            {
-                'name': engine.name,
-                'description': engine.description,
-                'installed': engine.installed,
-                'digest': engine.digest,
-                'global': True if engine.name == engine_store.global_engine else False,
-                'update_available': update_available
-            }
-        )
+            data.append(
+                {
+                    'name': engine.name,
+                    'description': engine.description,
+                    'installed': engine.installed,
+                    'digest': engine.digest,
+                    'global': True if engine.name == engine_store.global_engine else False,
+                    'update_available': update_available
+                }
+            )
     return data
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,18 +35,18 @@ setup(
     long_description_content_type="text/markdown",
     license='GPLv3',
     project_urls={
-        'Repository' : about['__repository_url__']
+        'Repository': about['__repository_url__']
     },
     packages=packages,
     setup_requires=[
         'setuptools_scm>=6.0.1,<7.0.0'
     ],
-    use_scm_version = {
+    use_scm_version={
         'root': '',
         'relative_to': __file__,
-        'fallback_version' : '_testing_',
-        'write_to' : 'hamlet/__version__.py',
-        'local_scheme' : 'no-local-version',
+        'fallback_version': '_testing_',
+        'write_to': 'hamlet/__version__.py',
+        'local_scheme': 'no-local-version',
     },
     install_requires=[
         'click>=7.0.0,<8.0.0',

--- a/tests/unit/backend/engine/test_engine.py
+++ b/tests/unit/backend/engine/test_engine.py
@@ -46,7 +46,7 @@ def test_global_engine_loading():
             GlobalEngineLoader()
         ]
 
-        assert len(engine_store.engines) == 0
+        assert len(engine_store.engines) == 1
 
         global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
 

--- a/tests/unit/command/deploy/test_test.py
+++ b/tests/unit/command/deploy/test_test.py
@@ -50,7 +50,12 @@ def mock_backend(unitlist=None):
         @mock.patch('hamlet.command.deploy.test.create_deployment')
         @mock.patch('hamlet.backend.query.context.Context')
         @mock.patch('hamlet.backend.query.template')
-        def wrapper(blueprint_mock, ContextClassMock, create_deployment_backend, create_template_backend, *args, **kwargs):
+        def wrapper(
+                blueprint_mock,
+                ContextClassMock,
+                create_deployment_backend,
+                create_template_backend,
+                *args, **kwargs):
             with tempfile.TemporaryDirectory() as temp_cache_dir:
 
                 ContextObjectMock = ContextClassMock()

--- a/tests/unit/command/engine/test_engine.py
+++ b/tests/unit/command/engine/test_engine.py
@@ -13,11 +13,12 @@ from hamlet.command.engine import (
 )
 
 
-def mock_engine(name, description, installed, digest=''):
+def mock_engine(name, description, installed, digest='', hidden=False):
     mock_engine = mock.Mock()
     mock_engine.name = name
     mock_engine.description = description
     mock_engine.digest = digest
+    mock_engine.hidden =hidden
     type(mock_engine).installed = mock.PropertyMock(return_value=installed)
 
     return mock_engine
@@ -32,13 +33,15 @@ def mock_backend():
                 mock_engine(
                     name='Name[1]',
                     description='Description[1]',
-                    installed=False
+                    installed=False,
+                    hidden=False
                 ),
                 mock_engine(
                     name='Name[2]',
                     description='Description[2]',
                     installed=True,
-                    digest='Digest[2]'
+                    digest='Digest[2]',
+                    hidden=True
                 )
             ]
 
@@ -64,7 +67,7 @@ def test_list_engines(mock_engine_store):
     assert result.exit_code == 0
     result = json.loads(result.output)
     print(result)
-    assert len(result) == 2
+    assert len(result) == 1
     assert {
         'name': 'Name[1]',
         'description': 'Description[1]',
@@ -73,15 +76,6 @@ def test_list_engines(mock_engine_store):
         'global': False,
         'update_available': None
     } in result
-    assert {
-        'name': 'Name[2]',
-        'description': 'Description[2]',
-        'digest': 'Digest[2]',
-        'installed': True,
-        'global': True,
-        'update_available': False
-    } in result
-
 
 @mock.patch("json.dumps", mock.MagicMock(return_value='{cool}'))
 @mock_backend()

--- a/tests/unit/command/engine/test_engine.py
+++ b/tests/unit/command/engine/test_engine.py
@@ -18,7 +18,7 @@ def mock_engine(name, description, installed, digest='', hidden=False):
     mock_engine.name = name
     mock_engine.description = description
     mock_engine.digest = digest
-    mock_engine.hidden =hidden
+    mock_engine.hidden = hidden
     type(mock_engine).installed = mock.PropertyMock(return_value=installed)
 
     return mock_engine
@@ -76,6 +76,7 @@ def test_list_engines(mock_engine_store):
         'global': False,
         'update_available': None
     } in result
+
 
 @mock.patch("json.dumps", mock.MagicMock(return_value='{cool}'))
 @mock_backend()


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

- Adds support for showing the hidden engines in the cli 
- Adds dynamic lookup loaders for both tram and train releases 
    - The trams are the nightly builds of offical hamlet engine and are named based on the date they were created
    - The trains are defined releases that have been marked for release by a maintainer. They are named using semver
 - fixes an issue in the build data collection which resulted in only one build source being shown

## Motivation and Context

This makes our release process feature complete  at this point in time and allows us to manage hamlet engine releases via the cli. 

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

