### PR TITLE
refactor: updating handling for engines

### DIFF
--- a/hamlet/backend/engine/__init__.py
+++ b/hamlet/backend/engine/__init__.py
@@ -20,6 +20,7 @@ from .engine_loader import (
 class EngineStoreException(BackendException):
     pass
 
+
 class EngineStoreMissingEngineException(EngineStoreException):
     pass
 
@@ -98,13 +99,12 @@ class EngineStore():
                 self._engines[engine.name] = engine
 
     def _load_external_engines(self, cache_timeout):
-
-        time_dif = (datetime.now()
-                        - datetime.strptime(
-                            self.store_state.get('last_external_load', datetime.now().isoformat(timespec='seconds')), "%Y-%m-%dT%H:%M:%S")).seconds
         if (datetime.now()
                 - datetime.strptime(
-                    self.store_state.get('last_external_load', datetime.now().isoformat(timespec='seconds')), "%Y-%m-%dT%H:%M:%S")).seconds >= cache_timeout:
+                    self.store_state.get(
+                        'last_external_load', datetime.now().isoformat(timespec='seconds')
+                    ), "%Y-%m-%dT%H:%M:%S")).seconds >= cache_timeout:
+
             for loader in self.external_engine_loaders:
                 for engine in loader.load():
                     engine.engine_dir = self.engine_dir

--- a/hamlet/backend/engine/engine_source.py
+++ b/hamlet/backend/engine/engine_source.py
@@ -109,8 +109,7 @@ class ContainerEngineSource(EngineSourceInterface):
             for engine_source_path in engine_source_paths:
                 with open(engine_source_path, 'r') as file:
                     source_name = str(engine_source_path)[
-                        len(dst_dir)
-                        :len(str(engine_source_path)) - len(engine_source)
+                        len(dst_dir):len(str(engine_source_path)) - len(engine_source)
                     ]
                     build_sources[source_name] = json.load(file)
 

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -8,7 +8,6 @@ from hamlet.backend.engine.exceptions import HamletEngineInvalidVersion
 from hamlet.utils import isWriteable
 from hamlet.env import HAMLET_HOME_DIR
 from hamlet.command.common.engine_setup import (
-    setup_initial_engines,
     check_engine_update,
     setup_global_engine,
     get_engine_env
@@ -55,16 +54,14 @@ def root(ctx, opts):
         )
 
     if homeWritable:
-
         try:
             setup_global_engine()
-            get_engine_env(opts.engine)
+
         except HamletEngineInvalidVersion:
             pass
 
         if ctx.invoked_subcommand != 'engine':
 
-            setup_initial_engines(opts.engine)
+            check_engine_update(opts.engine, opts.engine_update_install, opts.engine_update_interval)
 
-            if opts.check_engine_updates:
-                check_engine_update(opts.engine)
+        get_engine_env(opts.engine)

--- a/hamlet/command/common/config.py
+++ b/hamlet/command/common/config.py
@@ -49,7 +49,6 @@ class ConfigSchema(object):
         environment = ConfigParam(name='environment', type=str)
         segment = ConfigParam(name='segment', type=str)
         engine = ConfigParam(name='engine', type=str)
-        check_engine_updates = ConfigParam(name='check_engine_updates', type=bool)
 
     @matches_section("profile:*")
     class Profile(Default):
@@ -228,14 +227,24 @@ class Options:
         self._set_option('engine', value)
 
     @property
-    def check_engine_updates(self):
-        '''Check for updates to active engine'''
-        return self._get_option('check_engine_updates')
+    def engine_update_install(self):
+        '''Handle how engine updates are handled'''
+        return self._get_option('engine_update_install')
 
-    @check_engine_updates.setter
-    def check_engine_updates(self, value):
-        '''Set the check_engine_updates setting'''
-        self._set_option('check_engine_updates', value)
+    @engine_update_install.setter
+    def engine_update_install(self, value):
+        '''Set the engine_update_install setting'''
+        self._set_option('engine_update_install', value)
+
+    @property
+    def engine_update_interval(self):
+        '''How often to check for updates to active engine'''
+        return self._get_option('engine_update_interval')
+
+    @engine_update_interval.setter
+    def engine_update_interval(self, value):
+        '''How often to check for updates to active engine'''
+        self._set_option('engine_update_interval', value)
 
     @property
     def generation_framework(self):

--- a/hamlet/command/common/decorators.py
+++ b/hamlet/command/common/decorators.py
@@ -81,10 +81,17 @@ def common_engine_options(func):
         help='The name of the engine to use',
     )
     @click.option(
-        '--check-engine-updates/--no-check-engine-updates',
-        envvar='HAMLET_CHECK_ENGINE_UPDATES',
-        default=True,
-        help='Check for hamlet engine updates'
+        '--engine-update-install/--engine-update-check',
+        envvar='HAMLET_ENGINE_INSTALL_UPDATE',
+        default=False,
+        help='Check or install engine updates'
+    )
+    @click.option(
+        '--engine-update-interval',
+        envvar='HAMLET_ENGINE_UPDATE_INTERVAL',
+        type=click.INT,
+        default=3600,
+        help='How often in seconds to check for engine updates'
     )
     @click.pass_context
     @functools.wraps(func)
@@ -94,7 +101,8 @@ def common_engine_options(func):
         '''
         opts = ctx.ensure_object(Options)
         opts.engine = kwargs.pop('engine')
-        opts.check_engine_updates = kwargs.pop('check_engine_updates')
+        opts.engine_update_install = kwargs.pop('engine_update_install')
+        opts.engine_update_interval = kwargs.pop('engine_update_interval')
         kwargs['opts'] = opts
         return ctx.invoke(func, *args, **kwargs)
 

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -1,5 +1,4 @@
 import click
-from hamlet.backend import engine
 
 from hamlet.backend.engine import engine_store, EngineStoreMissingEngineException
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME, ENGINE_DEFAULT_GLOBAL_ENGINE
@@ -26,7 +25,6 @@ def setup_global_engine():
     if not global_engine.installed or not global_engine.up_to_date():
         global_engine.install()
 
-
     if engine_store.global_engine is not None:
         try:
             engine_store.get_engine(engine_store.global_engine).installed
@@ -45,6 +43,7 @@ def setup_global_engine():
             engine_store.find_engine(ENGINE_DEFAULT_GLOBAL_ENGINE).install()
 
         engine_store.global_engine = ENGINE_DEFAULT_GLOBAL_ENGINE
+
 
 def get_engine_env(engine_override):
 
@@ -66,13 +65,13 @@ def check_engine_update(engine_override, update_install, cache_timeout=0):
         engine = engine_store.find_engine(engine_name, cache_timeout=cache_timeout)
 
     except EngineStoreMissingEngineException:
-        cache_timeout=0
+        cache_timeout = 0
         engine = engine_store.find_engine(engine_name, cache_timeout=cache_timeout)
         update_install = True
 
     if not engine.up_to_date(cache_timeout=cache_timeout):
 
-        click.secho(f'[*] update available for current engine', fg='yellow')
+        click.secho('[*] update available for current engine', fg='yellow')
 
         if update_install:
             click.secho(f'[*] installing {engine_name} update', fg='yellow')

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -1,7 +1,7 @@
 import click
 from hamlet.backend import engine
 
-from hamlet.backend.engine import engine_source, engine_store, EngineStoreMissingEngineException
+from hamlet.backend.engine import engine_store, EngineStoreMissingEngineException
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME, ENGINE_DEFAULT_GLOBAL_ENGINE
 from hamlet.backend.engine.exceptions import HamletEngineInvalidVersion
 from hamlet.env import set_engine_env

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -60,13 +60,13 @@ def list_engines(show_hidden):
     '''
     data = []
 
-    for engine in engine_store.get_engines(local_only=False):
+    for engine in engine_store.find_engines(cache_timeout=0):
 
         update_available = None
         if (show_hidden and engine.hidden) or not engine.hidden:
             if engine.installed:
                 try:
-                    if engine.up_to_date(ignore_cache=True):
+                    if engine.up_to_date():
                         update_available = False
                     else:
                         update_available = True
@@ -112,11 +112,13 @@ def describe_engine(opts, name):
     else:
         engine_name = engine_store.global_engine
 
-    engine = engine_store.get_engine(engine_name, local_only=False)
+    engine = engine_store.find_engine(engine_name)
 
     try:
-        up_to_date = engine.up_to_date(ignore_cache=True)
-        latest_digest = engine.latest_digest(ignore_cache=True)
+
+        up_to_date = engine.up_to_date()
+        latest_digest = engine.get_latest_digest()
+
     except BaseException as e:
         click.secho(f'[!] Engine update failed for {engine.name}', fg='red', err=True)
         click.secho(f'[!]  {e}', fg='red', err=True)
@@ -229,7 +231,7 @@ def install_engine(name, force):
     Install an engine
     '''
     try:
-        engine = engine_store.get_engine(name, local_only=False)
+        engine = engine_store.find_engine(name, cache_timeout=0)
 
     except HamletEngineInvalidVersion as e:
         if force or click.confirm(
@@ -264,7 +266,7 @@ def set_engine(name):
     Sets the global engine used
     '''
 
-    engine = engine_store.get_engine(name, local_only=False)
+    engine = engine_store.find_engine(name, cache_timeout=0)
 
     if not engine.installed:
         click.echo('[*] installing engine')
@@ -294,9 +296,9 @@ def env(opts, environment_variable):
     '''
 
     if opts.engine is None:
-        engine = engine_store.get_engine(ENGINE_GLOBAL_NAME, local_only=True)
+        engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
     else:
-        engine = engine_store.get_engine(opts.engine, local_only=True)
+        engine = engine_store.get_engine(opts.engine)
 
     if environment_variable is None:
         click.echo('# run eval $(hamlet engine env) to set variables')

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -7,6 +7,7 @@ from tabulate import tabulate
 from hamlet.command import root as cli
 from hamlet.command.common import exceptions, config
 from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common.config import pass_options
 
 from hamlet.backend.engine import engine_store
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
@@ -222,14 +223,21 @@ def clean_engines(name):
 )
 @click.argument(
     'name',
-    required=True,
+    required=False,
     type=click.STRING
 )
 @exceptions.backend_handler()
-def install_engine(name, force):
+@pass_options
+def install_engine(opts, name, force):
     '''
-    Install an engine
+    Install or update an engine
     '''
+
+    if name is None:
+        name = opts.engine or engine_store.global_engine
+
+    click.echo(f'[*] installing engine - {name}')
+
     try:
         engine = engine_store.find_engine(name, cache_timeout=0)
 

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -9,7 +9,7 @@ from hamlet.command.common import exceptions, config
 from hamlet.command.common.display import json_or_table_option, wrap_text
 from hamlet.command.common.config import pass_options
 
-from hamlet.backend.engine import engine_store
+from hamlet.backend.engine import engine_store, EngineStoreMissingEngineException
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
 from hamlet.backend.engine.engine_code_source import EngineCodeSourceBuildData
 from hamlet.backend.engine.engine import HamletEngineInvalidVersion
@@ -274,11 +274,16 @@ def set_engine(name):
     Sets the global engine used
     '''
 
-    engine = engine_store.find_engine(name, cache_timeout=0)
+    try:
+        engine = engine_store.get_engine(name)
 
-    if not engine.installed:
-        click.echo('[*] installing engine')
-        engine.install()
+    except EngineStoreMissingEngineException:
+
+        engine = engine_store.find_engine(name, cache_timeout=0)
+
+        if not engine.installed:
+            click.echo('[*] installing engine')
+            engine.install()
 
     click.echo(f'[*] global engine set to {name}')
     engine_store.global_engine = name

--- a/hamlet/command/query/__init__.py
+++ b/hamlet/command/query/__init__.py
@@ -1,5 +1,3 @@
-import click
-
 from hamlet.command import root
 
 

--- a/tests/unit/backend/engine/test_engine.py
+++ b/tests/unit/backend/engine/test_engine.py
@@ -4,7 +4,6 @@ import hashlib
 from unittest import mock
 
 from hamlet.backend.engine import EngineStore
-from hamlet.backend.engine import engine
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
 from hamlet.backend.engine.engine import Engine
 from hamlet.backend.engine.engine_loader import GlobalEngineLoader, InstalledEngineLoader, UnicycleEngineLoader

--- a/tests/unit/backend/engine/test_engine.py
+++ b/tests/unit/backend/engine/test_engine.py
@@ -4,6 +4,7 @@ import hashlib
 from unittest import mock
 
 from hamlet.backend.engine import EngineStore
+from hamlet.backend.engine import engine
 from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
 from hamlet.backend.engine.engine import Engine
 from hamlet.backend.engine.engine_loader import GlobalEngineLoader, InstalledEngineLoader, UnicycleEngineLoader
@@ -42,13 +43,13 @@ def test_global_engine_loading():
     with tempfile.TemporaryDirectory() as store_dir:
         engine_store = EngineStore(store_dir=store_dir)
 
-        engine_store.engine_loaders = [
+        engine_store.local_engine_loaders = [
             GlobalEngineLoader()
         ]
 
         assert len(engine_store.get_engines()) == 1
 
-        global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME, local_only=True)
+        global_engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
 
         assert global_engine.name == ENGINE_GLOBAL_NAME
 
@@ -71,7 +72,7 @@ def test_installed_engine_loading():
     with tempfile.TemporaryDirectory() as store_dir:
         engine_store = EngineStore(store_dir=store_dir)
 
-        engine_store.engine_loaders = [
+        engine_store.local_engine_loaders = [
             InstalledEngineLoader(engine_store.engine_dir)
         ]
 
@@ -107,7 +108,7 @@ def test_installed_engine_loading():
         '''
         Use the Installed loader to discover the manually installed engine
         '''
-        discovered_engine = engine_store.get_engine('installed_engine', local_only=True)
+        discovered_engine = engine_store.get_engine('installed_engine')
         assert discovered_engine.name == 'installed_engine'
 
         generation_engine_path = os.path.join(discovered_engine.install_path, 'shim_source')
@@ -123,11 +124,11 @@ def test_unicycle_engine_loading(container_repository):
     with tempfile.TemporaryDirectory() as store_dir:
         engine_store = EngineStore(store_dir=store_dir)
 
-        engine_store.engine_loaders = [
+        engine_store.external_engine_loaders = [
             UnicycleEngineLoader()
         ]
 
-        unicycle_engine = engine_store.get_engine('unicycle', local_only=False)
+        unicycle_engine = engine_store.find_engine('unicycle')
         unicycle_engine.install()
 
         assert unicycle_engine.name == 'unicycle'

--- a/tests/unit/command/engine/test_engine.py
+++ b/tests/unit/command/engine/test_engine.py
@@ -46,6 +46,7 @@ def mock_backend():
             ]
 
             mock_engine_store.get_engines.return_value = mock_engines
+            mock_engine_store.find_engines.return_value = mock_engines
             type(mock_engine_store).global_engine = mock.PropertyMock(return_value='Name[2]')
 
             return func(mock_engine_store, *args, **kwargs)


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

A collection of updates and features to make update handling easier in the cli 

- limit how often the engines are loaded from external sources
- add a local list which will act as the default engine between the
cache timeouts
- limit how often digests are checked to determine updates
- handle missing engines when checking for updates and setting up the
global engine
- Allow for updating engines automatically when update detected
- Allow the user to define the update check interval
- Adds two levels of engines local and external which control the engine
loading process
- Updates the install-engine command to reinstall/update the current global engine or the engine defined by HAMLET_ENGINE. This allows for updating the engine without knowing the engine you are using 

## Motivation and Context

After some initial testing it was found that the automatic update process was running on each hamlet call. This meant that all engines were loaded from their external sources each time  in order to check for the update digest. This added some significant delays to the startup of the hamlet command 

Adding caching of the updates and loading means that the cli can run off the local engine state as much as possible and only calls out to the external engine sources when needed

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

