### PR TITLE
fix: default engine notification during install

### DIFF
--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -43,7 +43,7 @@ def setup_global_engine():
 
         except EngineStoreMissingEngineException:
             click.secho(
-                "[*] no default engine set using {ENGINE_DEFAULT_GLOBAL_ENGINE}"
+                f"[*] no default engine set using {ENGINE_DEFAULT_GLOBAL_ENGINE}"
             )
             engine_store.find_engine(ENGINE_DEFAULT_GLOBAL_ENGINE).install()
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

shows the name of the default global engine which will be installed when an engine is missing

## Motivation and Context

Minor regression with the changes from #174 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

