### PR TITLE
fix: handle engine set via env var

### DIFF
--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -55,7 +55,7 @@ def root(ctx, opts):
 
     if homeWritable:
         try:
-            setup_global_engine()
+            setup_global_engine(opts.engine)
 
         except HamletEngineInvalidVersion:
             pass

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -9,7 +9,7 @@ from hamlet.backend.engine.exceptions import HamletEngineInvalidVersion
 from hamlet.env import set_engine_env
 
 
-def setup_global_engine():
+def setup_global_engine(engine_override):
     """
     Always make sure the global engine is installed
     """
@@ -38,22 +38,31 @@ def setup_global_engine():
             engine_store.global_engine = engine_store.global_engine
 
     else:
+        if not engine_store.global_engine and engine_override:
+            engine_name = engine_override
+        else:
+            engine_name = ENGINE_DEFAULT_GLOBAL_ENGINE
+
         try:
-            engine_store.get_engine(ENGINE_DEFAULT_GLOBAL_ENGINE).installed
+            engine_store.get_engine(engine_name).installed
 
         except EngineStoreMissingEngineException:
             click.secho(
-                f"[*] no default engine set using {ENGINE_DEFAULT_GLOBAL_ENGINE}"
+                f"[*] no default engine set using {engine_name}"
             )
-            engine_store.find_engine(ENGINE_DEFAULT_GLOBAL_ENGINE).install()
+            engine_store.find_engine(engine_name).install()
 
-        engine_store.global_engine = ENGINE_DEFAULT_GLOBAL_ENGINE
+        engine_store.global_engine = engine_name
 
 
 def get_engine_env(engine_override):
 
     if engine_override is not None:
-        engine = engine_store.get_engine(engine_override)
+        try:
+            engine = engine_store.get_engine(engine_override)
+
+        except EngineStoreMissingEngineException:
+            engine = engine_store.find_engine(engine_override, cache_timeout=0)
     else:
         engine = engine_store.get_engine(ENGINE_GLOBAL_NAME)
 

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -47,9 +47,7 @@ def setup_global_engine(engine_override):
             engine_store.get_engine(engine_name).installed
 
         except EngineStoreMissingEngineException:
-            click.secho(
-                f"[*] no default engine set using {engine_name}"
-            )
+            click.secho(f"[*] no default engine set using {engine_name}")
             engine_store.find_engine(engine_name).install()
 
         engine_store.global_engine = engine_name


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)


## Description

- adds handling of engines set through environment variable which haven't been installed.
- If the global engine hasn't been set already use the env var as the global engine

## Motivation and Context

When setting the HAMLET_ENGINE env var to define the hamlet engine you want to use. If the engine wasn't installed the command would fail to setup the environment. 
Setting the environment variable will be common in CI environments so this needs to handle the install process automatically 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

