### PR TITLE
feat: show envvars for root command options

### DIFF
--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
     version = "unknown"
 
 
-@click.group("root")
+@click.group("root", context_settings=dict(max_content_width=240))
 @click.version_option(version)
 @decorators.common_engine_options
 @decorators.common_district_options

--- a/hamlet/command/common/decorators.py
+++ b/hamlet/command/common/decorators.py
@@ -21,6 +21,7 @@ def common_cli_config_options(func):
         envvar="HAMLET_CONFIG_FILE",
         type=click.Path(dir_okay=True, exists=True, writable=False, resolve_path=True),
         help="The path to your config file",
+        show_envvar=True,
     )
     @click.option(
         "-p",
@@ -28,6 +29,7 @@ def common_cli_config_options(func):
         default=None,
         envvar="HAMLET_PROFILE",
         help="The name of the profile to use for configuration",
+        show_envvar=True,
     )
     @click.pass_context
     @functools.wraps(func)
@@ -57,6 +59,7 @@ def common_logging_options(func):
         default="info",
         help="The minimum log event level",
         show_default=True,
+        show_envvar=True,
     )
     @click.pass_context
     @functools.wraps(func)
@@ -79,12 +82,14 @@ def common_engine_options(func):
         "--engine",
         envvar="HAMLET_ENGINE",
         help="The name of the engine to use",
+        show_envvar=True,
     )
     @click.option(
         "--engine-update-install/--engine-update-check",
         envvar="HAMLET_ENGINE_INSTALL_UPDATE",
         default=False,
         help="Check or install engine updates",
+        show_envvar=True,
     )
     @click.option(
         "--engine-update-interval",
@@ -92,6 +97,7 @@ def common_engine_options(func):
         type=click.INT,
         default=3600,
         help="How often in seconds to check for engine updates",
+        show_envvar=True,
     )
     @click.pass_context
     @functools.wraps(func)
@@ -121,6 +127,7 @@ def common_generation_options(func):
         type=CommaSplitParamType(),
         multiple=True,
         show_default=True,
+        show_envvar=True,
     )
     @click.option(
         "-f",
@@ -159,31 +166,37 @@ def common_district_options(func):
         "--root-dir",
         envvar="ROOT_DIR",
         help="The root CMDB directory (default: CMDB current location)",
+        show_envvar=True,
     )
     @click.option(
         "--tenant",
         envvar="TENANT",
         help="The tenant name to use (default: CMDB current location)",
+        show_envvar=True,
     )
     @click.option(
         "--account",
         envvar="ACCOUNT",
         help="The account name to use",
+        show_envvar=True,
     )
     @click.option(
         "--product",
         envvar="PRODUCT",
         help="The product name to use (default: CMDB current location)",
+        show_envvar=True,
     )
     @click.option(
         "--environment",
         envvar="ENVIRONMENT",
         help="The environment name to use (default: CMDB current location)",
+        show_envvar=True,
     )
     @click.option(
         "--segment",
         envvar="SEGMENT",
         help="The segment name to use (default: CMDB current location)",
+        show_envvar=True,
     )
     @click.pass_context
     @functools.wraps(func)

--- a/hamlet/command/component/__init__.py
+++ b/hamlet/command/component/__init__.py
@@ -8,7 +8,7 @@ from hamlet.command.component.list_occurrences import (
 )
 
 
-@cli.group("component")
+@cli.group("component", context_settings=dict(max_content_width=240))
 def component_group():
     """
     Provides information on the components used in a hamlet

--- a/hamlet/command/deploy/__init__.py
+++ b/hamlet/command/deploy/__init__.py
@@ -6,7 +6,7 @@ from .run import run_deployments as run_deployments_cmd
 from .test import test_deployments as test_deployments_cmd
 
 
-@cli.group("deploy")
+@cli.group("deploy", context_settings=dict(max_content_width=240))
 def group():
     """
     Deploys infrastructure based on the hamlet cmdb

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -34,7 +34,7 @@ def engines_table(data):
     )
 
 
-@cli.group("engine")
+@cli.group("engine", context_settings=dict(max_content_width=240))
 def group():
     """
     Manage the engine used by the executor

--- a/hamlet/command/entrance/__init__.py
+++ b/hamlet/command/entrance/__init__.py
@@ -12,7 +12,7 @@ from hamlet.backend.create import template as create_template_backend
 from hamlet.backend import query as query_backend
 
 
-@cli.group("entrance")
+@cli.group("entrance", context_settings=dict(max_content_width=240))
 def group():
     """
     Hamlet entrances provide access to the hamlet cmdb to perform different tasks

--- a/hamlet/command/generate/__init__.py
+++ b/hamlet/command/generate/__init__.py
@@ -4,7 +4,7 @@ from .cmdb import generate_account as generate_account_cmdb_cmd
 from .cmdb import generate_product as generate_product_cmdb_cmd
 
 
-@cli.group("generate")
+@cli.group("generate", context_settings=dict(max_content_width=240))
 def group():
     """
     Generates base CMDB file system structures

--- a/hamlet/command/generate/cmdb.py
+++ b/hamlet/command/generate/cmdb.py
@@ -11,7 +11,9 @@ from hamlet.command.generate import decorators
 from hamlet.command.common.exceptions import CommandError
 
 
-@click.command("tenant-cmdb", cls=DynamicCommand)
+@click.command(
+    "tenant-cmdb", cls=DynamicCommand, context_settings=dict(max_content_width=240)
+)
 @dynamic_option(
     "--tenant-id",
     help="The unique Id for the tenant",
@@ -54,7 +56,9 @@ def generate_tenant(ctx, prompt=None, use_default=None, **kwargs):
             raise CommandError(e)
 
 
-@click.command("account-cmdb", cls=DynamicCommand)
+@click.command(
+    "account-cmdb", cls=DynamicCommand, context_settings=dict(max_content_width=240)
+)
 @dynamic_option(
     "--account-id",
     help="The unique id for the account",
@@ -103,7 +107,9 @@ def generate_account(ctx, prompt=None, use_default=None, **kwargs):
             raise CommandError(e)
 
 
-@click.command("product-cmdb", cls=DynamicCommand)
+@click.command(
+    "product-cmdb", cls=DynamicCommand, context_settings=dict(max_content_width=240)
+)
 @dynamic_option(
     "--product-id",
     help="The Id of your product",

--- a/hamlet/command/manage/__init__.py
+++ b/hamlet/command/manage/__init__.py
@@ -6,7 +6,7 @@ from .file_crypto import file_crypto as file_crypto_cmd
 from .credentials_crypto import credentials_crypto as credentials_crypto_cmd
 
 
-@cli.group("manage")
+@cli.group("manage", context_settings=dict(max_content_width=240))
 def group():
     """
     Manages stuff

--- a/hamlet/command/release/__init__.py
+++ b/hamlet/command/release/__init__.py
@@ -15,26 +15,22 @@ def image_options(func):
     @click.option(
         "-u",
         "--deployment-unit",
-        envvar="DEPLOYMENT_UNIT",
         required=True,
         help="The deployment unit the image belongs to",
     )
     @click.option(
         "-r",
         "--build-reference",
-        envvar="BUILD_REFERENCE",
         required=True,
         help="The unique reference for the build of this image - usually git commit",
     )
     @click.option(
         "--code-tag",
-        envvar="CODE_TAG",
         help="A tag applied to your code repo which will be mapped to a build reference",
     )
     @click.option(
         "-f",
         "--image-format",
-        envvar="IMAGE_FORMAT",
         help="The format of the code image",
         type=click.Choice(
             [
@@ -54,7 +50,6 @@ def image_options(func):
     @click.option(
         "-s",
         "--registry-scope",
-        envvar="REGISTRY_SCOPE",
         help="The scope of the registry to update the image to",
     )
     @functools.wraps(func)
@@ -67,7 +62,7 @@ def image_options(func):
     return wrapper
 
 
-@cli.group("release")
+@cli.group("release", context_settings=dict(max_content_width=240))
 def group():
     """
     Manage the lifecycle of code images
@@ -80,25 +75,20 @@ def group():
 @image_options
 @click.option(
     "--image-path",
-    envvar="IMAGE_PATH",
     help="The path to the image can be zip file or directory",
     type=click.Path(file_okay=True, dir_okay=True, readable=True, resolve_path=True),
 )
 @click.option(
     "--dockerfile",
-    envvar="DOCKERFILE",
     help="The path to a dockerfile to create the image with",
     type=click.Path(file_okay=True, dir_okay=False, readable=True, resolve_path=True),
 )
 @click.option(
     "--docker-context",
-    envvar="DOCKER_CONTEXT",
     help="The docker context directory used with the dockerfile",
     type=click.Path(file_okay=False, dir_okay=True, readable=True, resolve_path=True),
 )
-@click.option(
-    "--docker-image", envvar="DOCKER_IMAGE", help="The tag of an existing docker image"
-)
+@click.option("--docker-image", help="The tag of an existing docker image")
 @exceptions.backend_handler()
 @config.pass_options
 def upload_image(opts, **kwargs):
@@ -115,13 +105,11 @@ def upload_image(opts, **kwargs):
 @image_options
 @click.option(
     "--source-account",
-    envvar="SOURCE_ACCOUNT",
     required=True,
     help="The name of the account to get the image from",
 )
 @click.option(
     "--source-environment",
-    envvar="SOURCE_ENVIRONMENT",
     required=True,
     help="The name of the environment to get the image from",
 )

--- a/hamlet/command/run/__init__.py
+++ b/hamlet/command/run/__init__.py
@@ -6,7 +6,7 @@ from .pipeline import pipeline as pipeline_cmd
 from .sentry_release import sentry_release as sentry_release_cmd
 
 
-@cli.group("run")
+@cli.group("run", context_settings=dict(max_content_width=240))
 def group():
     """
     Runs stuff

--- a/hamlet/command/schema/__init__.py
+++ b/hamlet/command/schema/__init__.py
@@ -34,7 +34,7 @@ def find_schemas_from_options(options, schema_type, schema_instances):
     return schemas
 
 
-@cli.group("schema")
+@cli.group("schema", context_settings=dict(max_content_width=240))
 def group():
     """
     Generates JSONSchema files for Hamlet data types

--- a/hamlet/command/test/__init__.py
+++ b/hamlet/command/test/__init__.py
@@ -5,7 +5,7 @@ from .generate import geneate as generate_cmd
 from .run import run as run_cmd
 
 
-@cli.group("test")
+@cli.group("test", context_settings=dict(max_content_width=240))
 def group():
     """
     Tests stuff

--- a/hamlet/command/visual/__init__.py
+++ b/hamlet/command/visual/__init__.py
@@ -40,7 +40,7 @@ def find_diagrams_from_options(options, ids):
     return diagrams
 
 
-@cli.group("visual")
+@cli.group("visual", context_settings=dict(max_content_width=240))
 def group():
     """
     Generates visual representations of your hamlet


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- makes the env var available in help to configure root level configuration options to make it easier to define these values
- ensures that the same screen width is used across all commands and groups to make help output readable
- removes env var options on subcommands and groups to make a consistent approach to running commands

## Motivation and Context

Makes it easier to find configuration options for users and to understand how the environment works 
remove the env var options provides a consistent approach and makes commands easier to understand where their config came from. The exception here is the root commands which often configure the CLI overall 

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

