### PR TITLE
feat: make the train engine the default global engine

### DIFF
--- a/hamlet/backend/engine/common.py
+++ b/hamlet/backend/engine/common.py
@@ -4,7 +4,7 @@ from hamlet.env import HAMLET_HOME_DIR
 
 ENGINE_STORE_DEFAULT_DIR = os.path.join(HAMLET_HOME_DIR, "engine")
 ENGINE_GLOBAL_NAME = "_global"
-ENGINE_DEFAULT_GLOBAL_ENGINE = "tram"
+ENGINE_DEFAULT_GLOBAL_ENGINE = "train"
 ENGINE_STATE_FILE_NAME = "engine_state.json"
 
 ENGINE_STATE_VERSION = "1.0.1"


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Makes the train engine the default engine selected if no other global engines are found

## Motivation and Context

Moves the cli to use a more stable release of hamlet by default

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

