### PR TITLE
feat: rename hamlet package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,15 +11,15 @@ You will need an existing hamlet workspace with `python` and `make` available ( 
 2. Hop into the executor clone location and setup a python venv
 
     ```bash
-    cd hamlet/executor/python/hamlet-cli
+    cd hamlet/executor/python/hamlet
     python -m venv .venv
     . .venv/bin/activate
 
     # install requirements
     pip install -r requirements/dev.txt
 
-    # Install the hamlet-cli into the venv in edit mode
-    pip install -e hamlet-cli
+    # Install the hamlet into the venv in edit mode
+    pip install -e hamlet
     ```
 
 When calling hamlet from within the venv the development installation will be used instead of the workspace installation
@@ -32,7 +32,7 @@ deactivate
 
 ## Development tasks
 
-Once you have setup the hamlet-cli the following make commands are available from the hamlet-cli directory in this repo
+Once you have setup the hamlet the following make commands are available from the hamlet directory in this repo
 
 ```bash
 # create test coverage report

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ format:
 .PHONY: install
 .ONESHELL:
 install:
-	pip uninstall hamlet-cli -y
-	pip install -e /hamlet-cli
+	pip uninstall hamlet -y
+	pip install -e /hamlet
 
 .PHONY: uninstall
 .ONESHELL:
 uninstall:
-	pip uninstall hamlet-cli -y
+	pip uninstall hamlet -y

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 ![release workflow](https://github.com/hamlet-io/executor-python/actions/workflows/release.yml/badge.svg)
-[![PyPI version](https://badge.fury.io/py/hamlet-cli.svg)](https://badge.fury.io/py/hamlet-cli)
+[![PyPI version](https://badge.fury.io/py/hamlet.svg)](https://badge.fury.io/py/hamlet)
 
 Hamlet deploy is a tool to manage infrastructure throughout the life of your application. With hamlet you define the functional components of your application along with the context they should be run in. The context includes things like environments, tenants, and policies that can be applied across all of your different applications.
 From this information hamlet then creates the infrastructure that will perform the function you have asked for and manages it over the life of your application.
@@ -72,13 +72,13 @@ Once you've got the prereqs installed the rest of hamlet is installed through th
 To install the hamlet cli/executor use the python package manager pip
 
 ```bash
-pip install hamlet-cli
+pip install hamlet
 ```
 
 If you want the latest changes that are in development we publish all commits as pre-releases
 
 ```bash
-pip install --pre hamlet-cli
+pip install --pre hamlet
 ```
 
 **Note** These builds can be unstable and aren't recommended for production usage

--- a/hamlet/__about__.py
+++ b/hamlet/__about__.py
@@ -16,7 +16,7 @@ try:
 except NameError:
     base_dir = None
 
-__title__ = "hamlet-cli"
+__title__ = "hamlet"
 __summary__ = "Building your infrastructure"
 __url__ = "https://hamlet.io"
 __repository_url__ = "https://github.com/hamletio/executor-python"


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

renames the setup.py package from hamlet-cli to hamlet
The existing package will be updated to handle this migration once the new package is published

## Motivation and Context

Creates a cleaner package name and highlights that the package also contains services other than the hamlet cli. You can use the backends if you want to

## How Has This Been Tested?

Tested on deploy

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

