### PR TITLE
feat: engine install control and get engine

### DIFF
--- a/tests/unit/command/engine/test_engine.py
+++ b/tests/unit/command/engine/test_engine.py
@@ -77,11 +77,11 @@ def test_list_engines(mock_engine_store):
     } in result
 
 
-@mock.patch("json.dumps", mock.MagicMock(return_value="{cool}"))
+@mock.patch("json.dumps", mock.MagicMock(return_value="{}"))
 @mock_backend()
 def test_describe_engine(mock_engine_store):
     cli = CliRunner()
-    result = cli.invoke(describe_engine, ["--name", "Name[1]"])
+    result = cli.invoke(describe_engine)
     print(result.output)
     assert result.exit_code == 0
 


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds more control over what happens when the install command is run to prevent unnecessary work
Adds a command to get the current engine and output as a string
Aligns the input for the all engine commands which require an engine name to use an argument instead of an option

## Motivation and Context

This makes it easy to perform engine management within CI pipelines to reduce the number of things done during the pipeline. This ensures that we don't have create unexpected dependencies on external services 

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

