### PR TITLE
feat: add district based deployment filters

### DIFF
--- a/hamlet/backend/deploy/__init__.py
+++ b/hamlet/backend/deploy/__init__.py
@@ -26,11 +26,13 @@ LIST_DEPLOYMENTS_QUERY = (
 )
 
 
+
 def find_deployments(
     deployment_mode,
     deployment_group,
     deployment_units,
     deployment_states=["deployed", "notdeployed"],
+    districts=["segment"],
     **kwargs,
 ):
 
@@ -48,11 +50,19 @@ def find_deployments(
     deployments = []
 
     for deployment in available_deployments:
-        if re.fullmatch(deployment_group, deployment["DeploymentGroup"]):
-            for deployment_unit in deployment_units:
-                if re.fullmatch(deployment_unit, deployment["DeploymentUnit"]):
-                    if deployment["CurrentState"] in deployment_states:
-                        deployments.append(deployment)
+
+        if "District" not in deployment:
+            if deployment["DeploymentGroup"] == "account":
+                deployment["District"] = "account"
+            else:
+                deployment["District"] = "segment"
+
+        if deployment["District"] in districts:
+            if re.fullmatch(deployment_group, deployment["DeploymentGroup"]):
+                for deployment_unit in deployment_units:
+                    if re.fullmatch(deployment_unit, deployment["DeploymentUnit"]):
+                        if deployment["CurrentState"] in deployment_states:
+                            deployments.append(deployment)
 
     return deployments
 

--- a/hamlet/backend/deploy/__init__.py
+++ b/hamlet/backend/deploy/__init__.py
@@ -26,7 +26,6 @@ LIST_DEPLOYMENTS_QUERY = (
 )
 
 
-
 def find_deployments(
     deployment_mode,
     deployment_group,

--- a/hamlet/command/deploy/create.py
+++ b/hamlet/command/deploy/create.py
@@ -45,6 +45,13 @@ from hamlet.backend.deploy import find_deployments, create_deployment
     help="The states of deployments to include",
 )
 @click.option(
+    "-d",
+    "--district",
+    default=["segment"],
+    multiple=True,
+    help="The districts to include deployments from",
+)
+@click.option(
     "-o",
     "--output-dir",
     type=click.Path(
@@ -64,6 +71,7 @@ def create_deployments(
     deployment_unit,
     deployment_state,
     output_dir,
+    district,
     **kwargs,
 ):
     """
@@ -75,6 +83,7 @@ def create_deployments(
         deployment_group,
         deployment_units=deployment_unit,
         deployment_states=deployment_state,
+        districts=district,
         **options.opts,
     )
 
@@ -88,6 +97,7 @@ def create_deployments(
 
         click.echo("")
         click.secho(f"[*] {deployment_group}/{deployment_unit}", bold=True, fg="green")
+        click.echo("")
 
         create_deployment(
             deployment_group,

--- a/hamlet/command/deploy/list.py
+++ b/hamlet/command/deploy/list.py
@@ -78,7 +78,12 @@ def deployments_table(data):
 @exceptions.backend_handler()
 @pass_options
 def list_deployments(
-    options, deployment_mode, deployment_group, deployment_unit, deployment_state, district
+    options,
+    deployment_mode,
+    deployment_group,
+    deployment_unit,
+    deployment_state,
+    district,
 ):
     """
     List available deployments

--- a/hamlet/command/deploy/list.py
+++ b/hamlet/command/deploy/list.py
@@ -16,15 +16,17 @@ def deployments_table(data):
                 wrap_text(row["DeploymentUnit"]),
                 wrap_text(row["DeploymentProvider"]),
                 wrap_text(row["CurrentState"]),
+                wrap_text(row["District"]),
             ]
         )
     return tabulate(
         tablerows,
         headers=[
-            "DeploymentGroup",
-            "DeploymentUnit",
-            "DeploymentProvider",
-            "CurrentState",
+            "Deployment Group",
+            "Deployment Unit",
+            "Provider",
+            "State",
+            "District",
         ],
         tablefmt="github",
     )
@@ -65,11 +67,18 @@ def deployments_table(data):
     multiple=True,
     help="The states of deployments to include",
 )
+@click.option(
+    "-d",
+    "--district",
+    default=["segment"],
+    multiple=True,
+    help="The districts to include deployments from",
+)
 @json_or_table_option(deployments_table)
 @exceptions.backend_handler()
 @pass_options
 def list_deployments(
-    options, deployment_mode, deployment_group, deployment_unit, deployment_state
+    options, deployment_mode, deployment_group, deployment_unit, deployment_state, district
 ):
     """
     List available deployments
@@ -79,5 +88,6 @@ def list_deployments(
         deployment_group,
         deployment_units=deployment_unit,
         deployment_states=deployment_state,
+        districts=district,
         **options.opts
     )

--- a/hamlet/command/deploy/run.py
+++ b/hamlet/command/deploy/run.py
@@ -45,6 +45,13 @@ from hamlet.backend.deploy import find_deployments, create_deployment, run_deplo
     help="The states of deployments to include",
 )
 @click.option(
+    "-d",
+    "--district",
+    default=["segment"],
+    multiple=True,
+    help="The districts to include deployments from",
+)
+@click.option(
     "-o",
     "--output-dir",
     type=click.Path(
@@ -78,6 +85,7 @@ def run_deployments(
     deployment_group,
     deployment_unit,
     deployment_state,
+    district,
     output_dir,
     refresh_outputs,
     confirm,
@@ -92,6 +100,7 @@ def run_deployments(
         deployment_group,
         deployment_units=deployment_unit,
         deployment_states=deployment_state,
+        districts=district,
         **options.opts,
     )
 

--- a/hamlet/command/deploy/test.py
+++ b/hamlet/command/deploy/test.py
@@ -36,6 +36,13 @@ from hamlet.backend.deploy import find_deployments, create_deployment
     help="The deployment unit pattern to match",
 )
 @click.option(
+    "-d",
+    "--district",
+    default=["segment"],
+    multiple=True,
+    help="The districts to include deployments from",
+)
+@click.option(
     "-o",
     "--output-dir",
     type=click.Path(
@@ -57,6 +64,7 @@ def test_deployments(
     deployment_mode,
     deployment_group,
     deployment_unit,
+    district,
     output_dir,
     pytest_args,
     silent,
@@ -77,6 +85,7 @@ def test_deployments(
         deployment_mode=deployment_mode,
         deployment_group=deployment_group,
         deployment_units=deployment_unit,
+        districts=district,
         **options.opts,
     )
 

--- a/tests/unit/command/deploy/test_deploy.py
+++ b/tests/unit/command/deploy/test_deploy.py
@@ -16,6 +16,7 @@ ALL_VALID_OPTIONS = collections.OrderedDict()
 ALL_VALID_OPTIONS["-o,--output-dir"] = "output_dir"
 ALL_VALID_OPTIONS["-u,--deployment-unit"] = "DeploymentUnit1"
 ALL_VALID_OPTIONS["-l,--deployment-group"] = "DeploymentGroup1"
+ALL_VALID_OPTIONS["-d,--district"] = "segment"
 ALL_VALID_OPTIONS["-m,--deployment-mode"] = "deployment_mode"
 ALL_VALID_OPTIONS["-s,--deployment-state"] = "deployed"
 ALL_VALID_OPTIONS["--refresh-outputs"] = True
@@ -93,6 +94,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation11"],
                         "CurrentState": "deployed",
+                        "District" : "segment"
                     },
                 },
                 {
@@ -101,8 +103,9 @@ unit_list = {
                         "DeploymentUnit": "DeploymentUnit2",
                         "DeploymentGroup": "DeploymentGroup2",
                         "DeploymentProvider": "aws",
-                        "Operations": ["Operation21"],
+                        "Operations": ["Operation2"],
                         "CurrentState": "deployed",
+                        "District" : "segment"
                     },
                 },
             ],

--- a/tests/unit/command/deploy/test_deploy.py
+++ b/tests/unit/command/deploy/test_deploy.py
@@ -94,7 +94,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation11"],
                         "CurrentState": "deployed",
-                        "District" : "segment"
+                        "District": "segment",
                     },
                 },
                 {
@@ -105,7 +105,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation2"],
                         "CurrentState": "deployed",
-                        "District" : "segment"
+                        "District": "segment",
                     },
                 },
             ],

--- a/tests/unit/command/deploy/test_list.py
+++ b/tests/unit/command/deploy/test_list.py
@@ -68,7 +68,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[1]",
                             "Operations": ["Operation[1]"],
                             "CurrentState": "deployed",
-                            "District": "segment"
+                            "District": "segment",
                         },
                     },
                     {
@@ -79,7 +79,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[2]",
                             "Operations": ["Operation[2]"],
                             "CurrentState": "deployed",
-                            "District": "segment"
+                            "District": "segment",
                         },
                     },
                 ],
@@ -95,7 +95,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[3]",
                             "Operations": ["Operation[3]"],
                             "CurrentState": "deployed",
-                            "District": "segment"
+                            "District": "segment",
                         },
                     },
                     {
@@ -106,7 +106,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[4]",
                             "Operations": ["Operation[4]"],
                             "CurrentState": "deployed",
-                            "District": "segment"
+                            "District": "segment",
                         },
                     },
                 ],
@@ -128,7 +128,7 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[1]",
         "Operations": ["Operation[1]"],
         "CurrentState": "deployed",
-        "District": "segment"
+        "District": "segment",
     } in result
     assert {
         "DeploymentUnit": "DeploymentUnit[2]",
@@ -136,7 +136,7 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[2]",
         "Operations": ["Operation[2]"],
         "CurrentState": "deployed",
-        "District": "segment"
+        "District": "segment",
     } in result
     assert {
         "DeploymentUnit": "DeploymentUnit[3]",
@@ -144,7 +144,7 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[3]",
         "Operations": ["Operation[3]"],
         "CurrentState": "deployed",
-        "District": "segment"
+        "District": "segment",
     } in result
     assert {
         "DeploymentUnit": "DeploymentUnit[4]",
@@ -152,5 +152,5 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[4]",
         "Operations": ["Operation[4]"],
         "CurrentState": "deployed",
-        "District": "segment"
+        "District": "segment",
     } in result

--- a/tests/unit/command/deploy/test_list.py
+++ b/tests/unit/command/deploy/test_list.py
@@ -68,6 +68,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[1]",
                             "Operations": ["Operation[1]"],
                             "CurrentState": "deployed",
+                            "District": "segment"
                         },
                     },
                     {
@@ -78,6 +79,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[2]",
                             "Operations": ["Operation[2]"],
                             "CurrentState": "deployed",
+                            "District": "segment"
                         },
                     },
                 ],
@@ -93,6 +95,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[3]",
                             "Operations": ["Operation[3]"],
                             "CurrentState": "deployed",
+                            "District": "segment"
                         },
                     },
                     {
@@ -103,6 +106,7 @@ def mock_backend(unitlist=None):
                             "DeploymentProvider": "DeploymentProvider[4]",
                             "Operations": ["Operation[4]"],
                             "CurrentState": "deployed",
+                            "District": "segment"
                         },
                     },
                 ],
@@ -124,6 +128,7 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[1]",
         "Operations": ["Operation[1]"],
         "CurrentState": "deployed",
+        "District": "segment"
     } in result
     assert {
         "DeploymentUnit": "DeploymentUnit[2]",
@@ -131,6 +136,7 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[2]",
         "Operations": ["Operation[2]"],
         "CurrentState": "deployed",
+        "District": "segment"
     } in result
     assert {
         "DeploymentUnit": "DeploymentUnit[3]",
@@ -138,6 +144,7 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[3]",
         "Operations": ["Operation[3]"],
         "CurrentState": "deployed",
+        "District": "segment"
     } in result
     assert {
         "DeploymentUnit": "DeploymentUnit[4]",
@@ -145,4 +152,5 @@ def test_query_list_deployments(blueprint_mock, ContextClassMock):
         "DeploymentProvider": "DeploymentProvider[4]",
         "Operations": ["Operation[4]"],
         "CurrentState": "deployed",
+        "District": "segment"
     } in result

--- a/tests/unit/command/deploy/test_test.py
+++ b/tests/unit/command/deploy/test_test.py
@@ -99,7 +99,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation11"],
                         "CurrentState": "deployed",
-                        "District": "segment"
+                        "District": "segment",
                     },
                 },
                 {
@@ -110,7 +110,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation21"],
                         "CurrentState": "deployed",
-                        "District": "segment"
+                        "District": "segment",
                     },
                 },
             ],

--- a/tests/unit/command/deploy/test_test.py
+++ b/tests/unit/command/deploy/test_test.py
@@ -16,6 +16,7 @@ ALL_VALID_OPTIONS = collections.OrderedDict()
 ALL_VALID_OPTIONS["-m,--deployment-mode"] = "DeploymentMode1"
 ALL_VALID_OPTIONS["-l,--deployment-group"] = "DeploymentGroup1"
 ALL_VALID_OPTIONS["-u,--deployment-unit"] = "DeploymentUnit1"
+ALL_VALID_OPTIONS["-d,--district"] = "segment"
 ALL_VALID_OPTIONS["-o,--output-dir"] = "output_dir"
 ALL_VALID_OPTIONS["-p,--pytest-args"] = "PyTestArg1"
 ALL_VALID_OPTIONS["-s,--silent"] = False
@@ -98,6 +99,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation11"],
                         "CurrentState": "deployed",
+                        "District": "segment"
                     },
                 },
                 {
@@ -108,6 +110,7 @@ unit_list = {
                         "DeploymentProvider": "aws",
                         "Operations": ["Operation21"],
                         "CurrentState": "deployed",
+                        "District": "segment"
                     },
                 },
             ],


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the ability to filter deployments based on their district
- sets a default district filter as segment to maintain the existing behaviour

## Motivation and Context

This allows for controlling all available deployments from the cli

## How Has This Been Tested?

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

