### PR TITLE
fix: use content digest as container digests

### DIFF
--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -122,7 +122,7 @@ class ContainerRepository:
         ]
 
     def get_tag_digest(self, tag):
-        return self.get_tag_manifest(tag)["config"]["digest"]
+        return self.get_tag_manifest(tag).headers["docker-content-digest"]
 
     def get_tag_manifest(self, tag):
         manifest_response = self.registry_client.get(
@@ -138,10 +138,11 @@ class ContainerRepository:
 
             raise e
 
-        return manifest_response.json()
+        return manifest_response
 
     def pull(self, tag, dst_dir):
-        manifest = self.get_tag_manifest(tag)
+        manifest_response = self.get_tag_manifest(tag)
+        manifest = manifest_response.json()
 
         with tempfile.TemporaryDirectory() as extract_dir:
             with tempfile.TemporaryDirectory() as stage_dir:
@@ -193,4 +194,4 @@ class ContainerRepository:
                         shutil.rmtree(dst_dir)
                     shutil.copytree(extract_dir, dst_dir, symlinks=True)
 
-        return manifest
+        return manifest_response.headers["docker-content-digest"]

--- a/hamlet/backend/engine/engine_source.py
+++ b/hamlet/backend/engine/engine_source.py
@@ -114,12 +114,12 @@ class ContainerEngineSource(EngineSourceInterface):
 
     def pull(self, dst_dir):
 
-        pull_manifest = self._container_repository.pull(self.tag, dst_dir)
+        pull_digest = self._container_repository.pull(self.tag, dst_dir)
 
         return EngineSourcePullState(
             name=self.name,
             type=self.__class__.__name__,
-            digest=pull_manifest["config"]["digest"],
+            digest=pull_digest,
             source_metadata={
                 "registry_url": self.registry_url,
                 "repository": self.repository,

--- a/tests/unit/backend/engine/test_engine.py
+++ b/tests/unit/backend/engine/test_engine.py
@@ -18,15 +18,14 @@ def mock_container_registry():
         @mock.patch("hamlet.backend.engine.engine_source.ContainerRepository")
         def wrapper(container_repository, *args, **kwargs):
 
-            container_repository.return_value.get_tag_digest.return_value = (
-                "config_digest[1]"
-            )
+            container_repository.return_value.get_tag_digest.return_value = "digest[1]"
             container_repository.return_value.get_tag_manifest.return_value = {
-                "config": {"digest": "config_digest[1]"}
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "config": {"digest": "config_digest[1]"},
+                "layers": [],
             }
-            container_repository.return_value.pull.return_value = {
-                "config": {"digest": "config_digest[1]"}
-            }
+            container_repository.return_value.pull.return_value = "digest[1]"
 
             return func(container_repository, *args, **kwargs)
 
@@ -130,7 +129,7 @@ def test_unicycle_engine_loading(container_repository):
 
         assert unicycle_engine.name == "unicycle"
 
-        container_digests = ["config_digest[1]"] * len(unicycle_engine.sources)
+        container_digests = ["digest[1]"] * len(unicycle_engine.sources)
         expected_digest = (
             "sha256:"
             + hashlib.sha256(":".join(container_digests).encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes an issue where the digest for the container wasn't based on the digest used by container registries to reference an image by digest. To do this the manifest needs to be retrieved from the header provided by the API rather than the digest included in the configuration itself. 

## Motivation and Context

Fixes #220 

allows for users to download the engine source using standard docker commands or to determine the specific version of hamlet code

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

