### PR TITLE
fix: provide details to set context for automation

### DIFF
--- a/hamlet/backend/automation_tasks/transfer_image/__init__.py
+++ b/hamlet/backend/automation_tasks/transfer_image/__init__.py
@@ -20,7 +20,13 @@ class TransferImageAutomationRunner(AutomationRunner):
         super().__init__(**kwargs)
 
         self._source_account = source_account
-        self._context_env = kwargs
+
+        self._context_env = {
+            "DEPLOYMENT_UNITS": deployment_unit,
+            "IMAGE_FORMATS": image_format,
+            "GIT_COMMIT": build_reference,
+            **kwargs,
+        }
 
         self._context_env["FROM_ACCOUNT"] = source_account
         self._context_env["FROM_ENVIRONMENT"] = source_environment

--- a/hamlet/backend/automation_tasks/upload_image/__init__.py
+++ b/hamlet/backend/automation_tasks/upload_image/__init__.py
@@ -25,7 +25,13 @@ class UploadImageAutomationRunner(AutomationRunner):
     ):
         super().__init__()
 
-        self._context_env = kwargs
+        self._context_env = {
+            "DEPLOYMENT_UNITS": deployment_unit,
+            "GIT_COMMIT": build_reference,
+            "IMAGE_FORMATS": image_format,
+            "REGISTRY_SCOPE": registry_scope,
+            **kwargs,
+        }
 
         self._script_list = [
             {"func": set_automation_context.run, "args": {"_is_cli": True}},


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Adds the provided user params for automation tasks through to the automation context instead of just to the command that needs them

## Motivation and Context

Errors were being raised during the automation set context as some required these env vars

## How Has This Been Tested?

tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

