### PR TITLE
feat: add cmdb save command

### DIFF
--- a/hamlet/__init__.py
+++ b/hamlet/__init__.py
@@ -1,16 +1,17 @@
 # Here we controll modules loading order
 # We can do it in command.__init__ but I guess this is a little bit more explicit
 import hamlet.command  # noqa
-import hamlet.command.generate  # noqa
-import hamlet.command.entrance  # noqa
-import hamlet.command.engine  # noqa
-import hamlet.command.test  # noqa
-import hamlet.command.manage  # noqa
-import hamlet.command.run  # noqa
-import hamlet.command.query  # noqa
-import hamlet.command.visual  # noqa
+import hamlet.command.cmdb #noqa
+import hamlet.command.component  # noqa
 import hamlet.command.deploy  # noqa
+import hamlet.command.engine  # noqa
+import hamlet.command.entrance  # noqa
+import hamlet.command.generate  # noqa
+import hamlet.command.manage  # noqa
+import hamlet.command.query  # noqa
+import hamlet.command.release  # noqa
+import hamlet.command.run  # noqa
 import hamlet.command.schema  # noqa
 import hamlet.command.setup  # noqa
-import hamlet.command.component  # noqa
-import hamlet.command.release  # noqa
+import hamlet.command.test  # noqa
+import hamlet.command.visual  # noqa

--- a/hamlet/__init__.py
+++ b/hamlet/__init__.py
@@ -1,7 +1,7 @@
 # Here we controll modules loading order
 # We can do it in command.__init__ but I guess this is a little bit more explicit
 import hamlet.command  # noqa
-import hamlet.command.cmdb #noqa
+import hamlet.command.cmdb  # noqa
 import hamlet.command.component  # noqa
 import hamlet.command.deploy  # noqa
 import hamlet.command.engine  # noqa

--- a/hamlet/backend/automation/save_cmdb_repos/__init__.py
+++ b/hamlet/backend/automation/save_cmdb_repos/__init__.py
@@ -1,0 +1,25 @@
+from hamlet.backend.common import runner
+
+
+def run(
+    account_repos=None,
+    product_repos=None,
+    commit_message=None,
+    reference=None,
+    tag=None,
+    log_level=None,
+    _is_cli=False,
+    env={},
+):
+
+    opts = {
+        "-a": account_repos,
+        "-m": commit_message,
+        "-p": product_repos,
+        "-r": reference,
+        "-t": tag
+    }
+    env = {"AUTOMATION_LOG_LEVEL": log_level, **env}
+    runner.run(
+        "saveCMDBRepos.sh", [], opts, env, _is_cli, script_base_path_env="AUTOMATION_DIR"
+    )

--- a/hamlet/backend/automation/save_cmdb_repos/__init__.py
+++ b/hamlet/backend/automation/save_cmdb_repos/__init__.py
@@ -17,9 +17,14 @@ def run(
         "-m": commit_message,
         "-p": product_repos,
         "-r": reference,
-        "-t": tag
+        "-t": tag,
     }
     env = {"AUTOMATION_LOG_LEVEL": log_level, **env}
     runner.run(
-        "saveCMDBRepos.sh", [], opts, env, _is_cli, script_base_path_env="AUTOMATION_DIR"
+        "saveCMDBRepos.sh",
+        [],
+        opts,
+        env,
+        _is_cli,
+        script_base_path_env="AUTOMATION_DIR",
     )

--- a/hamlet/backend/automation_tasks/save_repos/__init__.py
+++ b/hamlet/backend/automation_tasks/save_repos/__init__.py
@@ -2,24 +2,18 @@ from hamlet.backend.automation_tasks.base import AutomationRunner
 from hamlet.backend.automation import (
     set_automation_context,
     construct_tree,
-    save_cmdb_repos
+    save_cmdb_repos,
 )
 
 
 class SaveCMDBAutomationRunner(AutomationRunner):
     def __init__(
-        self,
-        account_repos,
-        commit_message,
-        product_repos,
-        reference,
-        tag,
-        **kwargs
+        self, account_repos, commit_message, product_repos, reference, tag, **kwargs
     ):
         super().__init__()
 
         self._context_env = {
-            "DEFER_REPO_PUSH" : "false",
+            "DEFER_REPO_PUSH": "false",
             **kwargs,
         }
 
@@ -42,7 +36,7 @@ class SaveCMDBAutomationRunner(AutomationRunner):
                     "product_repos": product_repos,
                     "reference": reference,
                     "tag": tag,
-                    "_is_cli": True
-                }
+                    "_is_cli": True,
+                },
             },
         ]

--- a/hamlet/backend/automation_tasks/save_repos/__init__.py
+++ b/hamlet/backend/automation_tasks/save_repos/__init__.py
@@ -1,0 +1,48 @@
+from hamlet.backend.automation_tasks.base import AutomationRunner
+from hamlet.backend.automation import (
+    set_automation_context,
+    construct_tree,
+    save_cmdb_repos
+)
+
+
+class SaveCMDBAutomationRunner(AutomationRunner):
+    def __init__(
+        self,
+        account_repos,
+        commit_message,
+        product_repos,
+        reference,
+        tag,
+        **kwargs
+    ):
+        super().__init__()
+
+        self._context_env = {
+            "DEFER_REPO_PUSH" : "false",
+            **kwargs,
+        }
+
+        self._script_list = [
+            {"func": set_automation_context.run, "args": {"_is_cli": True}},
+            {
+                "func": construct_tree.run,
+                "args": {
+                    "exclude_account_dirs": True,
+                    "exclude_product_dirs": True,
+                    "use_existing_tree": True,
+                    "_is_cli": True,
+                },
+            },
+            {
+                "func": save_cmdb_repos.run,
+                "args": {
+                    "account_repos": account_repos,
+                    "commit_message": commit_message,
+                    "product_repos": product_repos,
+                    "reference": reference,
+                    "tag": tag,
+                    "_is_cli": True
+                }
+            },
+        ]

--- a/hamlet/backend/common/runner.py
+++ b/hamlet/backend/common/runner.py
@@ -25,7 +25,7 @@ def __cli_params_to_script_call(
                     options_list.append(str(instance))
             else:
                 options_list.append(str(key))
-                options_list.append(str(value))
+                options_list.append(str(f"'{value}'"))
     script_fullpath = os.path.join(script_path, script_name)
     return " ".join([script_fullpath] + options_list + args)
 

--- a/hamlet/command/cmdb/__init__.py
+++ b/hamlet/command/cmdb/__init__.py
@@ -1,0 +1,57 @@
+import click
+
+from hamlet.command import root as cli
+from hamlet.command.common import exceptions, config
+
+from hamlet.backend.automation_tasks import save_repos as save_repos_backend
+
+
+@cli.group("cmdb", context_settings=dict(max_content_width=240))
+def group():
+    """
+    Manage CMDBs
+    """
+
+@group.command(
+    "commit-changes", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option(
+    "--accounts/--no-accounts",
+    default=False,
+    help="Include account repostories in save"
+)
+@click.option(
+    "--products/--no-products",
+    default=True,
+    help="Include product repositories in save"
+)
+@click.option(
+    "--commit-message",
+    required=True,
+    help="The commit message for these changes",
+)
+@click.option(
+    "--reference",
+    help="The repository reference to commit changes on",
+)
+@click.option(
+    "--tag",
+    help="The name of a tag to apply to the commit",
+)
+@exceptions.backend_handler()
+@config.pass_options
+def commit_changes(opts, accounts, products, commit_message, reference, tag, **kwargs):
+    """
+    Commit changes made to all CMDBs to their repositories
+    """
+
+    command_args = {
+        "account_repos": accounts,
+        "commit_message": commit_message,
+        "product_repos": products,
+        "reference": reference,
+        "tag" : tag
+    }
+
+    task = save_repos_backend.SaveCMDBAutomationRunner(**opts.opts, **kwargs, **command_args)
+    task.run()

--- a/hamlet/command/cmdb/__init__.py
+++ b/hamlet/command/cmdb/__init__.py
@@ -12,18 +12,19 @@ def group():
     Manage CMDBs
     """
 
+
 @group.command(
     "commit-changes", short_help="", context_settings=dict(max_content_width=240)
 )
 @click.option(
     "--accounts/--no-accounts",
     default=False,
-    help="Include account repostories in save"
+    help="Include account repostories in save",
 )
 @click.option(
     "--products/--no-products",
     default=True,
-    help="Include product repositories in save"
+    help="Include product repositories in save",
 )
 @click.option(
     "--commit-message",
@@ -50,8 +51,10 @@ def commit_changes(opts, accounts, products, commit_message, reference, tag, **k
         "commit_message": commit_message,
         "product_repos": products,
         "reference": reference,
-        "tag" : tag
+        "tag": tag,
     }
 
-    task = save_repos_backend.SaveCMDBAutomationRunner(**opts.opts, **kwargs, **command_args)
+    task = save_repos_backend.SaveCMDBAutomationRunner(
+        **opts.opts, **kwargs, **command_args
+    )
     task.run()


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds a CMDB command to save the state of all repositories

## Motivation and Context

This allows you to save a batch of changes performed across the CMDBS as a single command without having to know the directories where the CMDBS are

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/executor-bash/pull/273

### Dependent PRs:

- None

### Consumer Actions:

- None

