### PR TITLE
refactor: automation properties

### DIFF
--- a/hamlet/backend/automation_tasks/base.py
+++ b/hamlet/backend/automation_tasks/base.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 from abc import ABC
 
-from hamlet.backend.automation.properties_file import get_automation_properties
 from configparser import ConfigParser
 
 

--- a/hamlet/backend/automation_tasks/base.py
+++ b/hamlet/backend/automation_tasks/base.py
@@ -44,7 +44,7 @@ class AutomationRunner(ABC):
 
                 result = script["func"](env=self._context_env, **script["args"])
 
-                if result is not None:
+                if isinstance(result, dict):
                     self._context_env.update(result)
 
                 script_context_envs = self._load_properties_to_context(

--- a/hamlet/backend/automation_tasks/base.py
+++ b/hamlet/backend/automation_tasks/base.py
@@ -37,16 +37,17 @@ class AutomationRunner(ABC):
 
         self._context_env["AUTOMATION_PROVIDER"] = "hamletcli"
 
-        automation_properties = get_automation_properties(**self._context_env)
-        self._context_env.update(automation_properties)
-
         with tempfile.TemporaryDirectory() as tmp_dir:
 
             self._context_env["AUTOMATION_DATA_DIR"] = tmp_dir
 
             for script in self._script_list:
 
-                script["func"](env=self._context_env, **script["args"])
+                result = script["func"](env=self._context_env, **script["args"])
+
+                if result is not None:
+                    self._context_env.update(result)
+
                 script_context_envs = self._load_properties_to_context(
                     os.path.join(tmp_dir, "context.properties")
                 )

--- a/hamlet/backend/automation_tasks/transfer_image/__init__.py
+++ b/hamlet/backend/automation_tasks/transfer_image/__init__.py
@@ -1,5 +1,6 @@
 from hamlet.backend.automation_tasks.base import AutomationRunner
 from hamlet.backend.automation import (
+    properties_file,
     set_automation_context,
     manage_build_references,
     construct_tree,
@@ -32,6 +33,7 @@ class TransferImageAutomationRunner(AutomationRunner):
         self._context_env["FROM_ENVIRONMENT"] = source_environment
 
         self._script_list = [
+            {"func" : properties_file.get_automation_properties, "args" : { **self._context_env}},
             {
                 "func": set_automation_context.run,
                 "args": {"_is_cli": True, "release_mode": "promotion"},

--- a/hamlet/backend/automation_tasks/transfer_image/__init__.py
+++ b/hamlet/backend/automation_tasks/transfer_image/__init__.py
@@ -33,7 +33,10 @@ class TransferImageAutomationRunner(AutomationRunner):
         self._context_env["FROM_ENVIRONMENT"] = source_environment
 
         self._script_list = [
-            {"func" : properties_file.get_automation_properties, "args" : { **self._context_env}},
+            {
+                "func": properties_file.get_automation_properties,
+                "args": {**self._context_env},
+            },
             {
                 "func": set_automation_context.run,
                 "args": {"_is_cli": True, "release_mode": "promotion"},

--- a/hamlet/backend/automation_tasks/update_build/__init__.py
+++ b/hamlet/backend/automation_tasks/update_build/__init__.py
@@ -31,7 +31,10 @@ class UpdateBuildAutomationRunner(AutomationRunner):
         }
 
         self._script_list = [
-            {"func" : properties_file.get_automation_properties, "args" : { **self._context_env}},
+            {
+                "func": properties_file.get_automation_properties,
+                "args": {**self._context_env},
+            },
             {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {
                 "func": construct_tree.run,

--- a/hamlet/backend/automation_tasks/update_build/__init__.py
+++ b/hamlet/backend/automation_tasks/update_build/__init__.py
@@ -1,5 +1,6 @@
 from hamlet.backend.automation_tasks.base import AutomationRunner
 from hamlet.backend.automation import (
+    properties_file,
     set_automation_context,
     construct_tree,
     confirm_builds,
@@ -25,10 +26,12 @@ class UpdateBuildAutomationRunner(AutomationRunner):
             "CODE_TAGS": code_tag,
             "IMAGE_FORMATS": image_format,
             "REGISTRY_SCOPE": registry_scope,
+            "DEFER_REPO_PUSH": "true",
             **kwargs,
         }
 
         self._script_list = [
+            {"func" : properties_file.get_automation_properties, "args" : { **self._context_env}},
             {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {
                 "func": construct_tree.run,

--- a/hamlet/backend/automation_tasks/upload_image/__init__.py
+++ b/hamlet/backend/automation_tasks/upload_image/__init__.py
@@ -1,5 +1,6 @@
 from hamlet.backend.automation_tasks.base import AutomationRunner
 from hamlet.backend.automation import (
+    properties_file,
     set_automation_context,
     construct_tree,
     manage_images,
@@ -34,6 +35,7 @@ class UploadImageAutomationRunner(AutomationRunner):
         }
 
         self._script_list = [
+            {"func" : properties_file.get_automation_properties, "args" : { **self._context_env}},
             {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {
                 "func": construct_tree.run,

--- a/hamlet/backend/automation_tasks/upload_image/__init__.py
+++ b/hamlet/backend/automation_tasks/upload_image/__init__.py
@@ -35,7 +35,10 @@ class UploadImageAutomationRunner(AutomationRunner):
         }
 
         self._script_list = [
-            {"func" : properties_file.get_automation_properties, "args" : { **self._context_env}},
+            {
+                "func": properties_file.get_automation_properties,
+                "args": {**self._context_env},
+            },
             {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {
                 "func": construct_tree.run,

--- a/tests/unit/backend/automation_tasks/test_automation_runner.py
+++ b/tests/unit/backend/automation_tasks/test_automation_runner.py
@@ -3,8 +3,7 @@ from unittest import mock
 from hamlet.backend.automation_tasks.base import AutomationRunner
 
 
-@mock.patch("hamlet.backend.automation_tasks.base.get_automation_properties")
-def test_automation_runner_task(get_automation_properties):
+def test_automation_runner_task():
     """
     Tests that a task in the runner has been called
     """


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Removes running the properties lookup process from all automation runner commands
- Handle scripts which return output during automation tasks

## Motivation and Context

All of the automation tasks that the cli wraps require the properties generated by the get_properties function. Removing it from the default implementation of the task runner reduces the steps required to complete a task

## How Has This Been Tested?

tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

