### PR TITLE
feat: add occurrences query

### DIFF
--- a/hamlet/command/component/__init__.py
+++ b/hamlet/command/component/__init__.py
@@ -6,6 +6,9 @@ from hamlet.command.component.describe_occurrence import (
 from hamlet.command.component.list_occurrences import (
     list_occurrences as list_occurrences_command,
 )
+from hamlet.command.component.query_occurrences import (
+    query_occurrences as query_occurrences_command,
+)
 
 
 @cli.group("component", context_settings=dict(max_content_width=240))
@@ -18,3 +21,4 @@ def component_group():
 
 component_group.add_command(describe_occurrence_group)
 component_group.add_command(list_occurrences_command)
+component_group.add_command(query_occurrences_command)

--- a/hamlet/command/component/query_occurrences.py
+++ b/hamlet/command/component/query_occurrences.py
@@ -1,0 +1,26 @@
+import click
+import json
+
+from hamlet.command.common.config import pass_options
+from hamlet.command.common import exceptions
+
+from .common import query_occurrences_state
+
+
+@click.command(
+    "query-occurrences", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option(
+    "-q",
+    "--query",
+    required=True,
+    help="A JMESPath query to apply to the results",
+)
+@exceptions.backend_handler()
+@pass_options
+def query_occurrences(options, query):
+    """
+    Run a query over all occurrences
+    """
+    result = query_occurrences_state(options=options, query=query)
+    click.echo(json.dumps(result, indent=4))

--- a/tests/unit/command/component/test_occurrence.py
+++ b/tests/unit/command/component/test_occurrence.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 
 from hamlet.command.component.describe_occurrence import describe_occurrence
 from hamlet.command.component.list_occurrences import list_occurrences
+from hamlet.command.component.query_occurrences import query_occurrences
 
 from hamlet.command.component.common import DescribeContext
 
@@ -214,3 +215,20 @@ def test_describe_occurrence_query_attributes(blueprint_mock, ContextClassMock):
     print(result.exc_info)
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == {"ATTRIBUTE[1]": "AttributeValue[1]"}
+
+
+@mock_backend(occurrence_state_data)
+def test_query_occurrences(blueprint_mock, ContextClassMock):
+
+    cli = CliRunner()
+    result = cli.invoke(
+        query_occurrences,
+        [
+            "--query",
+            "Occurrences[0].{ComponentId:Core.Component.Id}",
+        ],
+    )
+
+    print(result.exc_info)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"ComponentId": "ComponentId[1]"}


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds a command to run JMESPath queries across all occurrences found in a given district

## Motivation and Context

This is an extension on the current describe-occurrence command which allows you to find out detailed information on a given occurrence. The query-occurrences command requires a JMESPath query which it runs over the full array of occurrences 

## How Has This Been Tested?
tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

