### PR TITLE
fix: handle container registry update failures

### DIFF
--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -68,7 +68,9 @@ class DockerRegistryV2Auth(httpx.Auth):
         except httpx.HTTPError as e:
             raise e
 
-        realm_token = json.loads(realm_response.text).get("access_token") or json.loads(realm_response.text).get("token")
+        realm_token = json.loads(realm_response.text).get("access_token") or json.loads(
+            realm_response.text
+        ).get("token")
         return f"Bearer {realm_token}"
 
     def _build_basic_auth_header(self, username, password) -> str:

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -64,12 +64,16 @@ def root(ctx, opts):
 
             if ctx.invoked_subcommand != "engine":
 
-                    check_engine_update(
-                        opts.engine, opts.engine_update_install, opts.engine_update_interval
-                    )
+                check_engine_update(
+                    opts.engine, opts.engine_update_install, opts.engine_update_interval
+                )
 
-        except httpx.HTTPError as e:
-            click.secho(f'[*] Could not check for updates - an error occurred accessing the registry', fg="yellow", error=True)
+        except httpx.HTTPError:
+            click.secho(
+                "[*] Could not check for updates - an error occurred accessing the registry",
+                fg="yellow",
+                error=True,
+            )
             pass
 
     get_engine_env(opts.engine)

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -1,5 +1,6 @@
 import click
 import os
+import httpx
 
 from hamlet.command.common import decorators
 from hamlet.command.common.exceptions import backend_handler
@@ -55,15 +56,20 @@ def root(ctx, opts):
 
     if homeWritable:
         try:
-            setup_global_engine(opts.engine)
+            try:
+                setup_global_engine(opts.engine)
 
-        except HamletEngineInvalidVersion:
+            except HamletEngineInvalidVersion:
+                pass
+
+            if ctx.invoked_subcommand != "engine":
+
+                    check_engine_update(
+                        opts.engine, opts.engine_update_install, opts.engine_update_interval
+                    )
+
+        except httpx.HTTPError as e:
+            click.secho(f'[*] Could not check for updates - an error occurred accessing the registry', fg="yellow", error=True)
             pass
 
-        if ctx.invoked_subcommand != "engine":
-
-            check_engine_update(
-                opts.engine, opts.engine_update_install, opts.engine_update_interval
-            )
-
-        get_engine_env(opts.engine)
+    get_engine_env(opts.engine)


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Add exception handling for when updates can not be checked through the container registry

## Motivation and Context

If an external container registry is having issues hamlet commands cannot be run 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

