### PR TITLE
fix: determine tree before context

### DIFF
--- a/hamlet/backend/automation/set_automation_context/__init__.py
+++ b/hamlet/backend/automation/set_automation_context/__init__.py
@@ -16,8 +16,8 @@ def run(
 ):
     env = {
         "AUTOMATION_LOG_LEVEL": log_level,
-        "AUTOMATION_CONTEXT_CREDENTIALS" : context_credentials,
-        **env
+        "AUTOMATION_CONTEXT_CREDENTIALS": context_credentials,
+        **env,
     }
     opts = {
         "-t": tenant,

--- a/hamlet/backend/automation/set_automation_context/__init__.py
+++ b/hamlet/backend/automation/set_automation_context/__init__.py
@@ -10,10 +10,15 @@ def run(
     product=None,
     environment=None,
     segment=None,
+    context_credentials=None,
     _is_cli=False,
     env={},
 ):
-    env = {"AUTOMATION_LOG_LEVEL": log_level, **env}
+    env = {
+        "AUTOMATION_LOG_LEVEL": log_level,
+        "AUTOMATION_CONTEXT_CREDENTIALS" : context_credentials,
+        **env
+    }
     opts = {
         "-t": tenant,
         "-a": account,

--- a/hamlet/backend/automation_tasks/save_repos/__init__.py
+++ b/hamlet/backend/automation_tasks/save_repos/__init__.py
@@ -18,15 +18,19 @@ class SaveCMDBAutomationRunner(AutomationRunner):
         }
 
         self._script_list = [
-            {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {
                 "func": construct_tree.run,
                 "args": {
-                    "exclude_account_dirs": True,
-                    "exclude_product_dirs": True,
                     "use_existing_tree": True,
                     "_is_cli": True,
                 },
+            },
+            {
+                "func": set_automation_context.run,
+                "args": {
+                    "_is_cli": True,
+                    "context_credentials": False
+                }
             },
             {
                 "func": save_cmdb_repos.run,

--- a/hamlet/backend/automation_tasks/save_repos/__init__.py
+++ b/hamlet/backend/automation_tasks/save_repos/__init__.py
@@ -27,10 +27,7 @@ class SaveCMDBAutomationRunner(AutomationRunner):
             },
             {
                 "func": set_automation_context.run,
-                "args": {
-                    "_is_cli": True,
-                    "context_credentials": False
-                }
+                "args": {"_is_cli": True, "context_credentials": False},
             },
             {
                 "func": save_cmdb_repos.run,

--- a/hamlet/backend/automation_tasks/transfer_image/__init__.py
+++ b/hamlet/backend/automation_tasks/transfer_image/__init__.py
@@ -34,21 +34,19 @@ class TransferImageAutomationRunner(AutomationRunner):
 
         self._script_list = [
             {
+                "func": construct_tree.run,
+                "args": {
+                    "use_existing_tree": True,
+                    "_is_cli": True,
+                },
+            },
+            {
                 "func": properties_file.get_automation_properties,
                 "args": {**self._context_env},
             },
             {
                 "func": set_automation_context.run,
                 "args": {"_is_cli": True, "release_mode": "promotion"},
-            },
-            {
-                "func": construct_tree.run,
-                "args": {
-                    "exclude_account_dirs": True,
-                    "exclude_product_dirs": True,
-                    "use_existing_tree": True,
-                    "_is_cli": True,
-                },
             },
             {
                 "func": manage_build_references.run,

--- a/hamlet/backend/automation_tasks/update_build/__init__.py
+++ b/hamlet/backend/automation_tasks/update_build/__init__.py
@@ -32,19 +32,17 @@ class UpdateBuildAutomationRunner(AutomationRunner):
 
         self._script_list = [
             {
-                "func": properties_file.get_automation_properties,
-                "args": {**self._context_env},
-            },
-            {"func": set_automation_context.run, "args": {"_is_cli": True}},
-            {
                 "func": construct_tree.run,
                 "args": {
-                    "exclude_account_dirs": True,
-                    "exclude_product_dirs": True,
                     "use_existing_tree": True,
                     "_is_cli": True,
                 },
             },
+            {
+                "func": properties_file.get_automation_properties,
+                "args": {**self._context_env},
+            },
+            {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {"func": confirm_builds.run, "args": {"_is_cli": True}},
             {"func": update_build_references.run, "args": {"_is_cli": True}},
         ]

--- a/hamlet/backend/automation_tasks/upload_image/__init__.py
+++ b/hamlet/backend/automation_tasks/upload_image/__init__.py
@@ -36,19 +36,17 @@ class UploadImageAutomationRunner(AutomationRunner):
 
         self._script_list = [
             {
-                "func": properties_file.get_automation_properties,
-                "args": {**self._context_env},
-            },
-            {"func": set_automation_context.run, "args": {"_is_cli": True}},
-            {
                 "func": construct_tree.run,
                 "args": {
-                    "exclude_account_dirs": True,
-                    "exclude_product_dirs": True,
                     "use_existing_tree": True,
                     "_is_cli": True,
                 },
             },
+            {
+                "func": properties_file.get_automation_properties,
+                "args": {**self._context_env},
+            },
+            {"func": set_automation_context.run, "args": {"_is_cli": True}},
             {
                 "func": manage_images.run,
                 "args": {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)


## Description

- Fixes the order of automation tasks when determining the context that a provided command is running in. Allowing for either directory based context or cli context to be used
- Includes support for disabling the automation credentials lookup when not required

## Motivation and Context

These updates align with the idea that you can use either the directory context or the cli context

## How Has This Been Tested?

Tested locally

## Related Changes

https://github.com/hamlet-io/executor-bash/pull/280 

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

