### PR TITLE
refactor: remove updating checking

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include *.md
 include setup-autocomplete.sh
+include setup-hamlet.sh
 include hamlet/backend/test/templates/*.tmpl
 recursive-include hamlet/backend/generate/ *

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -1,6 +1,5 @@
 import click
 import os
-import httpx
 
 from hamlet.command.common import decorators
 from hamlet.command.common.exceptions import backend_handler
@@ -9,7 +8,6 @@ from hamlet.backend.engine.exceptions import HamletEngineInvalidVersion
 from hamlet.utils import isWriteable
 from hamlet.env import HAMLET_GLOBAL_CONFIG
 from hamlet.command.common.engine_setup import (
-    check_engine_update,
     setup_global_engine,
     get_engine_env,
 )
@@ -56,24 +54,9 @@ def root(ctx, opts):
 
     if homeWritable:
         try:
-            try:
-                setup_global_engine(opts.engine)
+            setup_global_engine(opts.engine)
 
-            except HamletEngineInvalidVersion:
-                pass
-
-            if ctx.invoked_subcommand != "engine":
-
-                check_engine_update(
-                    opts.engine, opts.engine_update_install, opts.engine_update_interval
-                )
-
-        except httpx.HTTPError:
-            click.secho(
-                "[*] Could not check for updates - an error occurred accessing the registry",
-                fg="yellow",
-                error=True,
-            )
+        except HamletEngineInvalidVersion:
             pass
 
     get_engine_env(opts.engine)

--- a/hamlet/command/common/config.py
+++ b/hamlet/command/common/config.py
@@ -198,26 +198,6 @@ class Options:
         self._set_option("engine", value)
 
     @property
-    def engine_update_install(self):
-        """Handle how engine updates are handled"""
-        return self._get_option("engine_update_install")
-
-    @engine_update_install.setter
-    def engine_update_install(self, value):
-        """Set the engine_update_install setting"""
-        self._set_option("engine_update_install", value)
-
-    @property
-    def engine_update_interval(self):
-        """How often to check for updates to active engine"""
-        return self._get_option("engine_update_interval")
-
-    @engine_update_interval.setter
-    def engine_update_interval(self, value):
-        """How often to check for updates to active engine"""
-        self._set_option("engine_update_interval", value)
-
-    @property
     def generation_framework(self):
         """Get the generation_framework setting"""
         return self._get_option("generation_framework")

--- a/hamlet/command/common/decorators.py
+++ b/hamlet/command/common/decorators.py
@@ -75,21 +75,6 @@ def common_engine_options(func):
         help="The name of the engine to use",
         show_envvar=True,
     )
-    @click.option(
-        "--engine-update-install/--engine-update-check",
-        envvar="HAMLET_ENGINE_INSTALL_UPDATE",
-        default=False,
-        help="Check or install engine updates",
-        show_envvar=True,
-    )
-    @click.option(
-        "--engine-update-interval",
-        envvar="HAMLET_ENGINE_UPDATE_INTERVAL",
-        type=click.INT,
-        default=3600,
-        help="How often in seconds to check for engine updates",
-        show_envvar=True,
-    )
     @click.pass_context
     @functools.wraps(func)
     def wrapper(ctx, *args, **kwargs):
@@ -98,8 +83,6 @@ def common_engine_options(func):
         """
         opts = ctx.ensure_object(Options)
         opts.engine = kwargs.pop("engine")
-        opts.engine_update_install = kwargs.pop("engine_update_install")
-        opts.engine_update_interval = kwargs.pop("engine_update_interval")
         kwargs["opts"] = opts
         return ctx.invoke(func, *args, **kwargs)
 

--- a/setup-hamlet.sh
+++ b/setup-hamlet.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "Updating default hamlet engine"
+
+if which "hamlet"; then
+    hamlet engine install-engine --update
+fi

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import subprocess
 
 from setuptools import setup, find_packages
 from setuptools.command.install import install
+from setuptools.command.develop import develop
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -16,11 +17,24 @@ packages = find_packages(exclude=["tests.*", "tests"])
 class InstallCommand(install):
     def __post_install(self, dir):
         subprocess.call(["./setup-autocomplete.sh"])
+        subprocess.call(["./setup-hamlet.sh"])
 
     def run(self):
         install.run(self)
         self.execute(
-            self.__post_install, (self.install_lib,), msg="Setting up autocomplete..."
+            self.__post_install, (self.install_lib,), msg="Setting up hamlet..."
+        )
+
+
+class DevelopCommand(develop):
+    def __post_install(self, dir):
+        subprocess.call(["./setup-autocomplete.sh"])
+        subprocess.call(["./setup-hamlet.sh"])
+
+    def run(self):
+        develop.run(self)
+        self.execute(
+            self.__post_install, (self.install_lib,), msg="Setting up hamlet..."
         )
 
 
@@ -61,7 +75,10 @@ setup(
     include_package_data=True,
     python_requires=">=3.6",
     entry_points={"console_scripts": ["hamlet=hamlet:command.root"]},
-    cmdclass={"install": InstallCommand},
+    cmdclass={
+        "install": InstallCommand,
+        "develop": DevelopCommand,
+    },
     classifiers=[
         "Natural Language :: English",
         "Intended Audience :: Developers",


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

removes the auto update process and replaces it with a post install script for the cli to update the engine when a new version of the cli is installed

On install of the hamlet cli a post install script will install at least one version of the hamlet cli and when installing a new version of the cli it will automatically update the current global engine. This ensures that the cli is compatible with the latest changes if there are any for that release.

If the global engine isn't set the current engine details will be used to install an engine and set it to the global engine

## Motivation and Context

The update checking process was slowing down the command running and producing unreliable output when running commands. Since the cli is primarily used in CI/CD pipelines this has the potential to make pipelines fragile and slows down processing. 

This also removes implicit dependencies on github packages when running commands

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

