### PR TITLE
refactor: make missing home dir fatal

### DIFF
--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -1,11 +1,12 @@
 import click
 import os
+import tempfile
 
 from hamlet.command.common import decorators
-from hamlet.command.common.exceptions import backend_handler
-from hamlet.backend.engine.exceptions import HamletEngineInvalidVersion
-
-from hamlet.utils import isWriteable
+from hamlet.command.common.exceptions import (
+    backend_handler,
+    HamletHomeDirUnavailableException,
+)
 from hamlet.env import HAMLET_GLOBAL_CONFIG
 from hamlet.command.common.engine_setup import (
     setup_global_engine,
@@ -34,29 +35,11 @@ def root(ctx, opts):
 
     try:
         os.makedirs(HAMLET_GLOBAL_CONFIG.home_dir, exist_ok=True)
-    except OSError:
-        pass
+        testfile = tempfile.TemporaryFile(dir=HAMLET_GLOBAL_CONFIG.home_dir)
+        testfile.close()
 
-    homeWritable = isWriteable(HAMLET_GLOBAL_CONFIG.home_dir)
+    except OSError as e:
+        raise HamletHomeDirUnavailableException(str(e))
 
-    if not homeWritable:
-        click.secho(
-            (
-                f"[!] The hamlet home dir {HAMLET_GLOBAL_CONFIG.home_dir} isn't writable by this user\n"
-                "[!] Check the permissions on the directory"
-                " or change your home dir using the HAMLET_ENGINE_DIR environment variable\n"
-                "[!] We will continue but some parts of hamlet won't work and will raise errors of their own"
-            ),
-            fg="red",
-            bold=True,
-            err=True,
-        )
-
-    if homeWritable:
-        try:
-            setup_global_engine(opts.engine)
-
-        except HamletEngineInvalidVersion:
-            pass
-
+    setup_global_engine(opts.engine)
     get_engine_env(opts.engine)

--- a/hamlet/command/common/exceptions.py
+++ b/hamlet/command/common/exceptions.py
@@ -6,6 +6,7 @@ import httpx._exceptions as httpx_exceptions
 from click.exceptions import ClickException
 
 from hamlet.backend.common.exceptions import BackendException
+from hamlet.env import HAMLET_GLOBAL_CONFIG
 
 
 class CommandError(ClickException):
@@ -19,6 +20,25 @@ class CommandError(ClickException):
         )
         click.echo("")
         click.echo(self.format_message(), file=file, err=True)
+
+    def format_message(self):
+        return click.style(str(self.message))
+
+
+class HamletHomeDirUnavailableException(CommandError):
+    def show(self):
+        click.secho(
+            (
+                f"[!] The hamlet home dir {HAMLET_GLOBAL_CONFIG.home_dir} is not assessible\n"
+                f"[!] When testing access the reported error was:\n\n"
+                f"  {self.message} \n\n"
+                "[!] Check the permissions on the directory"
+                " or change your home dir using the HAMLET_ENGINE_DIR environment variable\n"
+            ),
+            fg="red",
+            bold=True,
+            err=True,
+        )
 
     def format_message(self):
         return click.style(str(self.message))

--- a/hamlet/utils/__init__.py
+++ b/hamlet/utils/__init__.py
@@ -1,6 +1,4 @@
 import click
-import tempfile
-import errno
 import os
 
 from click_configfile import Param
@@ -67,18 +65,6 @@ def dynamic_option(*args, **kwargs):
         return click.option(*args, **kwargs, cls=DynamicOption)(func)
 
     return decorator
-
-
-def isWriteable(path):
-    try:
-        testfile = tempfile.TemporaryFile(dir=path)
-        testfile.close()
-    except (OSError, IOError) as e:
-        if e.errno == errno.EACCES or e.errno == errno.EEXIST:
-            return False
-        e.filename = path
-        raise
-    return True
 
 
 class ConfigParam(Param):


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Changes the home dir write checking to be fatal instead of a large warning

## Motivation and Context

Now that engines are being used by most people to manage their access to hamlet dev resources the home dir is essentially required for all hamlet commands. Making this fatal simplifies the error processing and makes it easier to understand what needs to be done

## How Has This Been Tested?

Tested locally and with test suite 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

