### PR TITLE
refactor: move the cli cache dir to hamlet home

### DIFF
--- a/hamlet/backend/common/context.py
+++ b/hamlet/backend/common/context.py
@@ -86,7 +86,7 @@ class Context:
     # Cache dir path
     @property
     def cache_dir(self):
-        return os.path.join(self.__root_dir, "cache")
+        return self.__cache_dir
 
     @property
     def account_dir(self):
@@ -112,7 +112,13 @@ class Context:
         hash_str = f"{self.level_name}:{self.level_file}:{self.directory}:{json.dumps(self.config)}"
         return hashlib.md5(hash_str.encode()).hexdigest()
 
-    def __init__(self, directory: str, root_dir: str = None, config: dict = None):
+    def __init__(
+        self,
+        directory: str,
+        root_dir: str = None,
+        config: dict = None,
+        cache_dir: str = None,
+    ):
         config = config or {}
         self.config = config
         self.props = {}
@@ -127,6 +133,11 @@ class Context:
             self.__root_dir = root_dir
         else:
             self.__try_to_find_root()
+
+        if cache_dir is not None:
+            self.__cache_dir = cache_dir
+        else:
+            self.__cache_dir = os.path.join(self.__root_dir, "cache")
 
         if self.ACCOUNT_REQUIRED or self.TENANT_REQUIRED:
             self.__try_to_set_tenant()

--- a/hamlet/backend/query/__init__.py
+++ b/hamlet/backend/query/__init__.py
@@ -5,6 +5,7 @@ import tempfile
 import jmespath
 
 from jmespath.exceptions import JMESPathError
+from hamlet.env import HAMLET_GLOBAL_CONFIG
 from hamlet.backend.create import template
 from hamlet.backend.common import context
 from hamlet.backend.common import exceptions
@@ -162,7 +163,11 @@ class Query:
             tempdir = tempfile.gettempdir()
             output_dir = os.path.join(tempdir, "hamlet", "query", "mock")
         else:
-            ctx = context.Context(directory=cwd, root_dir=root_dir)
+            ctx = context.Context(
+                directory=cwd,
+                root_dir=root_dir,
+                cache_dir=HAMLET_GLOBAL_CONFIG.cli_cache_dir,
+            )
             output_dir = os.path.join(ctx.cache_dir, "query", ctx.md5_hash())
         output_filepath = os.path.join(output_dir, output_filename)
         if not os.path.isfile(output_filepath) or not use_cache:

--- a/hamlet/env.py
+++ b/hamlet/env.py
@@ -15,6 +15,9 @@ class GlobalEnvironmentConfig:
         self._config_dir = os.environ.get(
             "HAMLET_CLI_CONFIG_DIR", os.path.join(self._home_dir, "config")
         )
+        self._cli_cache_dir = os.environ.get(
+            "HAMLET_CLI_CACHE_DIR", os.path.join(self._home_dir, "cli_cache")
+        )
 
         self._engine = None
         self._engine_env = {"GENERATION_DIR": os.environ.get("GENERATION_DIR")}
@@ -26,6 +29,10 @@ class GlobalEnvironmentConfig:
     @property
     def config_dir(self):
         return self._config_dir
+
+    @property
+    def cli_cache_dir(self):
+        return self._cli_cache_dir
 
     @property
     def engine(self):


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

moves the cli cache dir from saving in root_dirs over to saving into a local cli cache

## Motivation and Context

Removes files that aren't required in the CMDB out of the CMDB and to an appropriate place 

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

