### PR TITLE
fix: require install of engine before set

### DIFF
--- a/hamlet/backend/engine/__init__.py
+++ b/hamlet/backend/engine/__init__.py
@@ -123,7 +123,11 @@ class EngineStore:
 
         if not allow_missing and not result:
             raise EngineStoreMissingEngineException(
-                f"Could not find engine {name} in engine store"
+                (
+                    f"[!] Could not find engine {name} in local engine store\n"
+                    "[!] Check that the engine is installed and the name is correct\n"
+                    f"[!] Run hamlet engine install-engine {name} to install it\n"
+                )
             )
 
         return result
@@ -144,7 +148,11 @@ class EngineStore:
 
         if not allow_missing and not result:
             raise EngineStoreMissingEngineException(
-                f"Could not find engine {name} in engine store"
+                (
+                    f"[!] Could not find an engine matching engine the name {name}\n"
+                    "[!] Check that the name of the engine is right\n"
+                    "[!] Run hamlet engine list-engines for available engines\n"
+                )
             )
 
         return result

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -37,6 +37,7 @@ def setup_global_engine(engine_override):
 
         try:
             engine_store.get_engine(default_engine)
+
         except EngineStoreMissingEngineException:
             engine_store.find_engine(default_engine).install()
 

--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -14,7 +14,6 @@ from hamlet.backend.engine.common import ENGINE_GLOBAL_NAME
 from hamlet.backend.engine.engine_code_source import EngineCodeSourceBuildData
 from hamlet.backend.engine.exceptions import (
     HamletEngineInvalidVersion,
-    EngineStoreMissingEngineException,
 )
 
 
@@ -272,20 +271,10 @@ def set_engine(opts, name):
     Sets the global engine used
     """
     name = name or opts.engine
+    engine = engine_store.get_engine(name)
 
-    try:
-        engine = engine_store.get_engine(name)
-
-    except EngineStoreMissingEngineException:
-
-        engine = engine_store.find_engine(name, cache_timeout=0)
-
-        if not engine.installed:
-            click.echo("[*] installing engine")
-            engine.install()
-
-    click.echo(f"[*] global engine set to {name}")
-    engine_store.global_engine = name
+    click.echo(f"[*] global engine set to {engine.name}")
+    engine_store.global_engine = engine.name
 
 
 @group.command(


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Instead off installing the engine when running set-engine now require it to be installed before this can happen.
- Updates exception messages to provide details on how to fix an engine lookup issue

## Motivation and Context

Makes it easier to understand the setup process and to align with the idea that there should be one way to do things

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

