### PR TITLE
fix: env preference order for runner

### DIFF
--- a/hamlet/backend/common/runner.py
+++ b/hamlet/backend/common/runner.py
@@ -49,8 +49,8 @@ def run(
 
     env_overrides = {
         **HAMLET_GLOBAL_CONFIG.engine_environment,
-        **__env_params_to_envvars(env),
         **os.environ,
+        **__env_params_to_envvars(env),
     }
     try:
         os.path.isdir(env_overrides[script_base_path_env])


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes the preference order for environment variables when running backend tasks

## Motivation and Context

Makes the most specific env var parameters i.e. the ones provided by hamlet cli itself the preferred values to use when passing commands to the runner. This mainly fixes an issue where overrides performed during the automation processing were being overridden by the os environment variables

## How Has This Been Tested?

tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

