### PR TITLE
feat: reference command group

### DIFF
--- a/hamlet/__init__.py
+++ b/hamlet/__init__.py
@@ -8,7 +8,7 @@ import hamlet.command.engine  # noqa
 import hamlet.command.entrance  # noqa
 import hamlet.command.generate  # noqa
 import hamlet.command.manage  # noqa
-import hamlet.command.query  # noqa
+import hamlet.command.reference  # noqa
 import hamlet.command.release  # noqa
 import hamlet.command.run  # noqa
 import hamlet.command.schema  # noqa

--- a/hamlet/command/entrance/__init__.py
+++ b/hamlet/command/entrance/__init__.py
@@ -20,7 +20,7 @@ def group():
     pass
 
 
-LIST_ENTRANCES_QUERY = "Entrances[]" ".{" "Type:Type," "Description:Description" "}"
+LIST_ENTRANCES_QUERY = "Entrances[].{Type:Type,Description:Description}"
 
 
 def entrances_table(data):

--- a/hamlet/command/reference/__init__.py
+++ b/hamlet/command/reference/__init__.py
@@ -1,0 +1,190 @@
+import os
+import click
+import json
+
+from tabulate import tabulate
+
+from hamlet.command import root as cli
+from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common import exceptions
+from hamlet.command.common.config import pass_options
+from hamlet.backend import query as query_backend
+
+
+def query_info_output(options, query, query_params=None, sub_query_text=None):
+    query_args = {
+        **options.opts,
+        "generation_entrance": "info",
+        "output_filename": "info.json",
+        "use_cache": False,
+    }
+    query_result = query_backend.run(
+        **query_args,
+        cwd=os.getcwd(),
+        query_text=query,
+        query_params=query_params,
+        sub_query_text=sub_query_text
+    )
+
+    return query_result
+
+
+@cli.group("reference", context_settings=dict(max_content_width=240))
+def group():
+    """
+    Reference data provided in the CMDB
+    """
+    pass
+
+
+def reference_types_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row["Type"]),
+                wrap_text(row["PluralType"]),
+                wrap_text(row["Description"]),
+            ]
+        )
+    return tabulate(
+        tablerows, headers=["Type", "PluralType", "Description"], tablefmt="github"
+    )
+
+
+@group.command(
+    "list-reference-types", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="A query to filter out the reference results")
+@json_or_table_option(reference_types_table)
+@exceptions.backend_handler()
+@pass_options
+def list_reference_types(options, query):
+    """
+    Lists the types of references available
+    """
+
+    LIST_REFERENCE_TYPES_QUERY = (
+        "ReferenceTypes[]"
+        ".{"
+        "Type:Type,"
+        "PluralType:PluralType,"
+        "Description:Description"
+        "}"
+    )
+
+    return query_info_output(options, LIST_REFERENCE_TYPES_QUERY, None, query)
+
+
+@group.command(
+    "describe-reference-type",
+    short_help="",
+    context_settings=dict(max_content_width=240),
+)
+@click.option(
+    "-t", "--type", required=True, help="The type of the reference to describe"
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def describe_reference_type(options, type, query):
+    """
+    Describes a specific reference type
+    """
+    DESCRIBE_REFERENCE_TYPE_QUERY = "ReferenceTypes[?Type=={type}] | [0]"
+
+    click.echo(
+        json.dumps(
+            query_info_output(
+                options, DESCRIBE_REFERENCE_TYPE_QUERY, {"type": type}, query
+            ),
+            indent=2,
+        )
+    )
+
+
+@group.command(
+    "query-reference-types", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def query_reference_types(options, query):
+    """
+    Query across all reference types
+    """
+    click.echo(
+        json.dumps(
+            query_info_output(options, "ReferenceTypes[]", None, query), indent=2
+        )
+    )
+
+
+def reference_list_data_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row["Id"]),
+                wrap_text(row["Type"]),
+            ]
+        )
+    return tabulate(tablerows, headers=["Id", "Type"], tablefmt="github")
+
+
+@group.command(
+    "list-references", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="A query to filter out the reference results")
+@json_or_table_option(reference_list_data_table)
+@exceptions.backend_handler()
+@pass_options
+def list_references(options, query):
+    """
+    Lists the references available
+    """
+
+    LIST_REFERENCES_QUERY = "ReferenceData[].{Id:Id,Type:Type}"
+
+    return query_info_output(options, LIST_REFERENCES_QUERY, {}, query)
+
+
+@group.command(
+    "describe-reference", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option(
+    "-t", "--type", required=True, help="The type of the reference to describe"
+)
+@click.option("-i", "--id", required=True, help="The id of the reference to describe")
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def describe_reference(options, type, id, query):
+    """
+    Describes a specific reference
+    """
+    DESCRIBE_REFERENCE_QUERY = "ReferenceData[?Type=={type} && Id=={id}] | [0]"
+
+    click.echo(
+        json.dumps(
+            query_info_output(
+                options, DESCRIBE_REFERENCE_QUERY, {"type": type, "id": id}, query
+            ),
+            indent=2,
+        )
+    )
+
+
+@group.command(
+    "query-references", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def query_references(options, query):
+    """
+    Query across all references
+    """
+    click.echo(
+        json.dumps(query_info_output(options, "ReferenceData[]", None, query), indent=2)
+    )

--- a/tests/unit/command/reference/test_describe.py
+++ b/tests/unit/command/reference/test_describe.py
@@ -1,0 +1,166 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.reference import describe_reference_type, describe_reference
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+info_mock_output = {
+    "ReferenceTypes": [
+        {
+            "Type": "ReferenceType[1]",
+            "Description": "ReferenceDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[1]",
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Description": "ReferenceDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[2]",
+        },
+    ],
+    "ReferenceData": [
+        {
+            "Type": "ReferenceType[1]",
+            "Id": "ReferenceDataId[1]",
+            "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Id": "ReferenceDataId[2]",
+            "Properties": {"ReferenceProperty[2]": "ReferencePropertyValue[2]"},
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+DECSCRIBE_TYPE_VALID_OPTIONS = collections.OrderedDict()
+DECSCRIBE_TYPE_VALID_OPTIONS["!-t,--type"] = "ReferenceType[1]"
+DECSCRIBE_TYPE_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_describe_reference_type_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        describe_reference_type,
+        DECSCRIBE_TYPE_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_describe_reference_type(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_reference_type, ["--type", "ReferenceType[1]"], obj=obj
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert {
+        "Type": "ReferenceType[1]",
+        "Description": "ReferenceDescription[1]",
+        "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+        "PluralType": "ReferencePluralType[1]",
+    } == result
+
+
+DECSCRIBE_REFERENCE_VALID_OPTIONS = collections.OrderedDict()
+DECSCRIBE_REFERENCE_VALID_OPTIONS["!-t,--type"] = "ReferenceType[1]"
+DECSCRIBE_REFERENCE_VALID_OPTIONS["!-i,--id"] = "ReferenceDataId[1]"
+DECSCRIBE_REFERENCE_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_describe_reference_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        describe_reference,
+        DECSCRIBE_REFERENCE_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_describe_reference(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_reference,
+        ["--type", "ReferenceType[1]", "--id", "ReferenceDataId[1]"],
+        obj=obj,
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert {
+        "Type": "ReferenceType[1]",
+        "Id": "ReferenceDataId[1]",
+        "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+    } == result

--- a/tests/unit/command/reference/test_list.py
+++ b/tests/unit/command/reference/test_list.py
@@ -1,0 +1,156 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.reference import list_reference_types, list_references
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+info_mock_output = {
+    "ReferenceTypes": [
+        {
+            "Type": "ReferenceType[1]",
+            "Description": "ReferenceDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[1]",
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Description": "ReferenceDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[2]",
+        },
+    ],
+    "ReferenceData": [
+        {
+            "Type": "ReferenceType[1]",
+            "Id": "ReferenceDataId[1]",
+            "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Id": "ReferenceDataId[2]",
+            "Properties": {"ReferenceProperty[2]": "ReferencePropertyValue[2]"},
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+LIST_TYPES_VALID_OPTIONS = collections.OrderedDict()
+LIST_TYPES_VALID_OPTIONS["-q,--query"] = "[]"
+LIST_TYPES_VALID_OPTIONS["--output-format"] = "json"
+
+
+@mock_backend(info_mock_output)
+def test_list_reference_types_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(), list_reference_types, LIST_TYPES_VALID_OPTIONS, blueprint_mock.run
+    )
+
+
+@mock_backend(info_mock_output)
+def test_list_reference_types(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(list_reference_types, ["--output-format", "json"], obj=obj)
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 2
+    assert {
+        "Type": "ReferenceType[1]",
+        "PluralType": "ReferencePluralType[1]",
+        "Description": "ReferenceDescription[1]",
+    } in result
+    assert {
+        "Type": "ReferenceType[2]",
+        "PluralType": "ReferencePluralType[2]",
+        "Description": "ReferenceDescription[2]",
+    } in result
+
+
+LIST_REFERENCES_VALID_OPTIONS = collections.OrderedDict()
+LIST_REFERENCES_VALID_OPTIONS["-q,--query"] = "[]"
+LIST_REFERENCES_VALID_OPTIONS["--output-format"] = "json"
+
+
+@mock_backend(info_mock_output)
+def test_list_references_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(), list_references, LIST_REFERENCES_VALID_OPTIONS, blueprint_mock.run
+    )
+
+
+@mock_backend(info_mock_output)
+def test_list_references(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(list_references, ["--output-format", "json"], obj=obj)
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 2
+    assert {"Id": "ReferenceDataId[1]", "Type": "ReferenceType[1]"} in result
+    assert {"Id": "ReferenceDataId[2]", "Type": "ReferenceType[2]"} in result

--- a/tests/unit/command/reference/test_query.py
+++ b/tests/unit/command/reference/test_query.py
@@ -1,0 +1,164 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.reference import query_reference_types, query_references
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+info_mock_output = {
+    "ReferenceTypes": [
+        {
+            "Type": "ReferenceType[1]",
+            "Description": "ReferenceDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[1]",
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Description": "ReferenceDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[2]",
+        },
+    ],
+    "ReferenceData": [
+        {
+            "Type": "ReferenceType[1]",
+            "Id": "ReferenceDataId[1]",
+            "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Id": "ReferenceDataId[2]",
+            "Properties": {"ReferenceProperty[2]": "ReferencePropertyValue[2]"},
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+QUERY_TYPES_VALID_OPTIONS = collections.OrderedDict()
+QUERY_TYPES_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_query_reference_types_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        query_reference_types,
+        QUERY_TYPES_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_query_reference_types(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        query_reference_types, ["--query", "[?Type==`ReferenceType[1]`]"], obj=obj
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 1
+    assert {
+        "Type": "ReferenceType[1]",
+        "Description": "ReferenceDescription[1]",
+        "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+        "PluralType": "ReferencePluralType[1]",
+    } in result
+
+
+QUERY_REFERENCES_VALID_OPTIONS = collections.OrderedDict()
+QUERY_REFERENCES_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_query_references_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        query_references,
+        QUERY_REFERENCES_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_query_references(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        query_references,
+        ["--query", "[?Id==`ReferenceDataId[1]`]"],
+        obj=obj,
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 1
+    assert {
+        "Type": "ReferenceType[1]",
+        "Id": "ReferenceDataId[1]",
+        "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+    } in result


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds a new command group for reference data
- Adds list,query and describe commands for reference types and reference data

## Motivation and Context

Makes it possible to discover available reference data within a solution as its final result. Currently you need to be able to layer all input sources over the top and find the most specific instance of a given reference to know its values 

## How Has This Been Tested?

Tested locally and with test suite 

## Related Changes


### Prerequisite PRs:

- 

### Dependent PRs:

- None

### Consumer Actions:

- None

