### PR TITLE
refactor: align account infra to state dir

### DIFF
--- a/hamlet/backend/create/template/context_tree.py
+++ b/hamlet/backend/create/template/context_tree.py
@@ -94,8 +94,10 @@ def find_gen3_account_dir(root_dir, account):
     return matches[0]
 
 
-def find_gen3_account_infrastructure_dir(root_dir, account):
+def find_gen3_account_state_dir(root_dir, account):
     patterns = [
+        os.path.join("**", account, "state" ),
+        os.path.join("**", "state", "**", account),
         os.path.join("**", "infrastructure", "**", account),
         os.path.join("**", account, "infrastructure"),
     ]
@@ -170,15 +172,15 @@ def find_gen3_dirs(
     set_gen3_env_dir(e, "ACCOUNT_DIR", prefix, find_gen3_account_dir(root_dir, account))
     set_gen3_env_dir(
         e,
-        "ACCOUNT_INFRASTRUCTURE_DIR",
+        "ACCOUNT_STATE_DIR",
         prefix,
-        find_gen3_account_infrastructure_dir(root_dir, account),
+        find_gen3_account_state_dir(root_dir, account),
     )
     e[prefix + "ACCOUNT_SETTINGS_DIR"] = os.path.join(
         get_gen3_env(e, "ACCOUNT_DIR", prefix), "settings"
     )
     e[prefix + "ACCOUNT_OPERATIONS_DIR"] = os.path.join(
-        get_gen3_env(e, "ACCOUNT_INFRASTRUCTURE_DIR", prefix), "operations"
+        get_gen3_env(e, "ACCOUNT_STATE_DIR", prefix), "operations"
     )
 
     if product:

--- a/hamlet/backend/create/template/context_tree.py
+++ b/hamlet/backend/create/template/context_tree.py
@@ -96,7 +96,7 @@ def find_gen3_account_dir(root_dir, account):
 
 def find_gen3_account_state_dir(root_dir, account):
     patterns = [
-        os.path.join("**", account, "state" ),
+        os.path.join("**", account, "state"),
         os.path.join("**", "state", "**", account),
         os.path.join("**", "infrastructure", "**", account),
         os.path.join("**", account, "infrastructure"),

--- a/tests/integration/backend/create/template/test_context_tree.py
+++ b/tests/integration/backend/create/template/test_context_tree.py
@@ -34,9 +34,9 @@ def test_find_gen3_dirs(clear_cmdb, cmdb):
         assert tenant_dir == ct.find_gen3_tenant_dir(root_dir, tenant_name)
         account_base_dir = os.path.join(root_dir, "accounts", account_name)
         account_dir = os.path.join(account_base_dir, "config")
-        account_infr_dir = os.path.join(account_base_dir, "infrastructure")
+        account_state_dir = os.path.join(account_base_dir, "infrastructure")
         assert account_dir == ct.find_gen3_account_dir(root_dir, account_name)
-        assert account_infr_dir == ct.find_gen3_account_infrastructure_dir(
+        assert account_state_dir == ct.find_gen3_account_state_dir(
             root_dir, account_name
         )
         product_base_dir = os.path.join(root_dir, product_name)
@@ -64,9 +64,9 @@ def test_find_gen3_dirs(clear_cmdb, cmdb):
         assert e.TENANT_DIR == tenant_dir
 
         assert e.ACCOUNT_DIR == account_dir
-        assert e.ACCOUNT_INFRASTRUCTURE_DIR == account_infr_dir
+        assert e.ACCOUNT_STATE_DIR == account_state_dir
         assert e.ACCOUNT_SETTINGS_DIR == os.path.join(account_dir, "settings")
-        assert e.ACCOUNT_OPERATIONS_DIR == os.path.join(account_infr_dir, "operations")
+        assert e.ACCOUNT_OPERATIONS_DIR == os.path.join(account_state_dir, "operations")
         product_settings_dir = os.path.join(product_dir, "settings")
         product_operations_dir = os.path.join(product_infr_dir, "operations")
         product_solutions_dir = os.path.join(product_dir, "solutionsv2")


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)


## Description

- Updates the usage of account infrastructure dir to use state instead

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Aligns with the changes in https://github.com/hamlet-io/executor-bash/pull/299


## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

