### PR TITLE
feat: add layer and component type info

### DIFF
--- a/hamlet/__init__.py
+++ b/hamlet/__init__.py
@@ -7,6 +7,7 @@ import hamlet.command.deploy  # noqa
 import hamlet.command.engine  # noqa
 import hamlet.command.entrance  # noqa
 import hamlet.command.generate  # noqa
+import hamlet.command.layer  # noqa
 import hamlet.command.manage  # noqa
 import hamlet.command.reference  # noqa
 import hamlet.command.release  # noqa

--- a/hamlet/command/component/__init__.py
+++ b/hamlet/command/component/__init__.py
@@ -9,6 +9,11 @@ from hamlet.command.component.list_occurrences import (
 from hamlet.command.component.query_occurrences import (
     query_occurrences as query_occurrences_command,
 )
+from hamlet.command.component.component_types import (
+    list_component_types as list_component_types_command,
+    describe_component_type as describe_component_type_command,
+    query_component_types as query_component_types_command,
+)
 
 
 @cli.group("component", context_settings=dict(max_content_width=240))
@@ -22,3 +27,6 @@ def component_group():
 component_group.add_command(describe_occurrence_group)
 component_group.add_command(list_occurrences_command)
 component_group.add_command(query_occurrences_command)
+component_group.add_command(list_component_types_command)
+component_group.add_command(describe_component_type_command)
+component_group.add_command(query_component_types_command)

--- a/hamlet/command/component/component_types.py
+++ b/hamlet/command/component/component_types.py
@@ -1,0 +1,107 @@
+import os
+import click
+import json
+
+from tabulate import tabulate
+
+from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common import exceptions
+from hamlet.command.common.config import pass_options
+from hamlet.backend import query as query_backend
+
+
+def query_info_output(options, query, query_params=None, sub_query_text=None):
+    query_args = {
+        **options.opts,
+        "generation_entrance": "info",
+        "output_filename": "info.json",
+        "use_cache": False,
+    }
+    query_result = query_backend.run(
+        **query_args,
+        cwd=os.getcwd(),
+        query_text=query,
+        query_params=query_params,
+        sub_query_text=sub_query_text
+    )
+
+    return query_result
+
+
+def component_types_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row["Type"]),
+                wrap_text(row["Description"]),
+            ]
+        )
+    return tabulate(
+        tablerows,
+        headers=["Type", "Description"],
+        tablefmt="github",
+    )
+
+
+@click.command(
+    "list-component-types", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="A query to filter out the results")
+@json_or_table_option(component_types_table)
+@exceptions.backend_handler()
+@pass_options
+def list_component_types(options, query):
+    """
+    Lists the types of components available
+    """
+
+    LIST_COMPONENT_TYPES_QUERY = (
+        "ComponentTypes[]" ".{" "Type:Type," "Description:Description" "}"
+    )
+
+    return query_info_output(options, LIST_COMPONENT_TYPES_QUERY, None, query)
+
+
+@click.command(
+    "describe-component-type",
+    short_help="",
+    context_settings=dict(max_content_width=240),
+)
+@click.option(
+    "-t", "--type", required=True, help="The type of the component to describe"
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def describe_component_type(options, type, query):
+    """
+    Describes a specific component type
+    """
+    DESCRIBE_COMPONENT_TYPE_QUERY = "ComponentTypes[?Type=={type}] | [0]"
+
+    click.echo(
+        json.dumps(
+            query_info_output(
+                options, DESCRIBE_COMPONENT_TYPE_QUERY, {"type": type}, query
+            ),
+            indent=2,
+        )
+    )
+
+
+@click.command(
+    "query-component-types", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def query_component_types(options, query):
+    """
+    Query across all component types
+    """
+    click.echo(
+        json.dumps(
+            query_info_output(options, "ComponentTypes[]", None, query), indent=2
+        )
+    )

--- a/hamlet/command/layer/__init__.py
+++ b/hamlet/command/layer/__init__.py
@@ -1,0 +1,186 @@
+import os
+import click
+import json
+
+from tabulate import tabulate
+
+from hamlet.command import root as cli
+from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command.common import exceptions
+from hamlet.command.common.config import pass_options
+from hamlet.backend import query as query_backend
+
+
+def query_info_output(options, query, query_params=None, sub_query_text=None):
+    query_args = {
+        **options.opts,
+        "generation_entrance": "info",
+        "output_filename": "info.json",
+        "use_cache": False,
+    }
+    query_result = query_backend.run(
+        **query_args,
+        cwd=os.getcwd(),
+        query_text=query,
+        query_params=query_params,
+        sub_query_text=sub_query_text
+    )
+
+    return query_result
+
+
+@cli.group("layer", context_settings=dict(max_content_width=240))
+def group():
+    """
+    Layers provided in the CMDB
+    """
+    pass
+
+
+def layer_types_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row["Type"]),
+                wrap_text(row["ReferenceLookupType"]),
+                wrap_text(row["Description"]),
+            ]
+        )
+    return tabulate(
+        tablerows,
+        headers=["Type", "ReferenceLookupType", "Description"],
+        tablefmt="github",
+    )
+
+
+@group.command(
+    "list-layer-types", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="A query to filter out the results")
+@json_or_table_option(layer_types_table)
+@exceptions.backend_handler()
+@pass_options
+def list_layer_types(options, query):
+    """
+    Lists the types of layers available
+    """
+
+    LIST_LAYER_TYPES_QUERY = (
+        "LayerTypes[]"
+        ".{"
+        "Type:Type,"
+        "ReferenceLookupType:ReferenceLookupType,"
+        "Description:Description"
+        "}"
+    )
+
+    return query_info_output(options, LIST_LAYER_TYPES_QUERY, None, query)
+
+
+@group.command(
+    "describe-layer-type",
+    short_help="",
+    context_settings=dict(max_content_width=240),
+)
+@click.option("-t", "--type", required=True, help="The type of the layer to describe")
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def describe_layer_type(options, type, query):
+    """
+    Describes a specific layer type
+    """
+    DESCRIBE_LAYER_TYPE_QUERY = "LayerTypes[?Type=={type}] | [0]"
+
+    click.echo(
+        json.dumps(
+            query_info_output(
+                options, DESCRIBE_LAYER_TYPE_QUERY, {"type": type}, query
+            ),
+            indent=2,
+        )
+    )
+
+
+@group.command(
+    "query-layer-types", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def query_layer_types(options, query):
+    """
+    Query across all layer types
+    """
+    click.echo(
+        json.dumps(query_info_output(options, "LayerTypes[]", None, query), indent=2)
+    )
+
+
+def layer_list_data_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row["Id"]),
+                wrap_text(row["Type"]),
+            ]
+        )
+    return tabulate(tablerows, headers=["Id", "Type"], tablefmt="github")
+
+
+@group.command(
+    "list-layers", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="A query to filter out the results")
+@json_or_table_option(layer_list_data_table)
+@exceptions.backend_handler()
+@pass_options
+def list_layers(options, query):
+    """
+    Lists the layers available
+    """
+
+    LIST_LAYERS_QUERY = "LayerData[].{Id:Id,Type:Type}"
+
+    return query_info_output(options, LIST_LAYERS_QUERY, {}, query)
+
+
+@group.command(
+    "describe-layer", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-t", "--type", required=True, help="The type of the layer to describe")
+@click.option("-i", "--id", required=True, help="The id of the layer to describe")
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def describe_layer(options, type, id, query):
+    """
+    Describes a specific layer
+    """
+    DESCRIBE_LAYER_QUERY = "LayerData[?Type=={type} && Id=={id}] | [0]"
+
+    click.echo(
+        json.dumps(
+            query_info_output(
+                options, DESCRIBE_LAYER_QUERY, {"type": type, "id": id}, query
+            ),
+            indent=2,
+        )
+    )
+
+
+@group.command(
+    "query-layers", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="a query on the describe result")
+@exceptions.backend_handler()
+@pass_options
+def query_layers(options, query):
+    """
+    Query across all layers
+    """
+    click.echo(
+        json.dumps(query_info_output(options, "LayerData[]", None, query), indent=2)
+    )

--- a/tests/unit/command/component/test_component_types.py
+++ b/tests/unit/command/component/test_component_types.py
@@ -1,0 +1,112 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.component.component_types import describe_component_type
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+info_mock_output = {
+    "ComponentTypes": [
+        {
+            "Type": "ComponentType[1]",
+            "Description": "ComponentDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+        },
+        {
+            "Type": "ComponentType[2]",
+            "Description": "ComponentDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+DECSCRIBE_TYPE_VALID_OPTIONS = collections.OrderedDict()
+DECSCRIBE_TYPE_VALID_OPTIONS["!-t,--type"] = "ComponentType[1]"
+DECSCRIBE_TYPE_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_describe_component_type_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        describe_component_type,
+        DECSCRIBE_TYPE_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_describe_component_type(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_component_type, ["--type", "ComponentType[1]"], obj=obj
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert {
+        "Type": "ComponentType[1]",
+        "Description": "ComponentDescription[1]",
+        "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+    } == result

--- a/tests/unit/command/layer/test_describe.py
+++ b/tests/unit/command/layer/test_describe.py
@@ -1,0 +1,164 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.layer import describe_layer_type, describe_layer
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+info_mock_output = {
+    "LayerTypes": [
+        {
+            "Type": "LayerType[1]",
+            "Description": "LayerDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+            "ReferenceLookupType": "LayerReferenceLookupType[1]",
+        },
+        {
+            "Type": "LayerType[2]",
+            "Description": "LayerDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+            "ReferenceLookupType": "LayerReferenceLookupType[2]",
+        },
+    ],
+    "LayerData": [
+        {
+            "Type": "LayerType[1]",
+            "Id": "LayerDataId[1]",
+            "Properties": {"LayerProperty[1]": "LayerPropertyValue[1]"},
+        },
+        {
+            "Type": "LayerType[2]",
+            "Id": "LayerDataId[2]",
+            "Properties": {"LayerProperty[2]": "LayerPropertyValue[2]"},
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+DECSCRIBE_TYPE_VALID_OPTIONS = collections.OrderedDict()
+DECSCRIBE_TYPE_VALID_OPTIONS["!-t,--type"] = "ReferenceType[1]"
+DECSCRIBE_TYPE_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_describe_layer_type_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        describe_layer_type,
+        DECSCRIBE_TYPE_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_describe_layer_type(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(describe_layer_type, ["--type", "LayerType[1]"], obj=obj)
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert {
+        "Type": "LayerType[1]",
+        "Description": "LayerDescription[1]",
+        "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+        "ReferenceLookupType": "LayerReferenceLookupType[1]",
+    } == result
+
+
+DECSCRIBE_LAYER_VALID_OPTIONS = collections.OrderedDict()
+DECSCRIBE_LAYER_VALID_OPTIONS["!-t,--type"] = "LayerType[1]"
+DECSCRIBE_LAYER_VALID_OPTIONS["!-i,--id"] = "LayerDataId[1]"
+DECSCRIBE_LAYER_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_describe_layer_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        describe_layer,
+        DECSCRIBE_LAYER_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_describe_layer(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_layer,
+        ["--type", "LayerType[1]", "--id", "LayerDataId[1]"],
+        obj=obj,
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert {
+        "Type": "LayerType[1]",
+        "Id": "LayerDataId[1]",
+        "Properties": {"LayerProperty[1]": "LayerPropertyValue[1]"},
+    } == result

--- a/tests/unit/command/layer/test_list.py
+++ b/tests/unit/command/layer/test_list.py
@@ -1,0 +1,156 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.reference import list_reference_types, list_references
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+info_mock_output = {
+    "ReferenceTypes": [
+        {
+            "Type": "ReferenceType[1]",
+            "Description": "ReferenceDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[1]",
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Description": "ReferenceDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[2]",
+        },
+    ],
+    "ReferenceData": [
+        {
+            "Type": "ReferenceType[1]",
+            "Id": "ReferenceDataId[1]",
+            "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Id": "ReferenceDataId[2]",
+            "Properties": {"ReferenceProperty[2]": "ReferencePropertyValue[2]"},
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+LIST_TYPES_VALID_OPTIONS = collections.OrderedDict()
+LIST_TYPES_VALID_OPTIONS["-q,--query"] = "[]"
+LIST_TYPES_VALID_OPTIONS["--output-format"] = "json"
+
+
+@mock_backend(info_mock_output)
+def test_list_reference_types_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(), list_reference_types, LIST_TYPES_VALID_OPTIONS, blueprint_mock.run
+    )
+
+
+@mock_backend(info_mock_output)
+def test_list_reference_types(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(list_reference_types, ["--output-format", "json"], obj=obj)
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 2
+    assert {
+        "Type": "ReferenceType[1]",
+        "PluralType": "ReferencePluralType[1]",
+        "Description": "ReferenceDescription[1]",
+    } in result
+    assert {
+        "Type": "ReferenceType[2]",
+        "PluralType": "ReferencePluralType[2]",
+        "Description": "ReferenceDescription[2]",
+    } in result
+
+
+LIST_REFERENCES_VALID_OPTIONS = collections.OrderedDict()
+LIST_REFERENCES_VALID_OPTIONS["-q,--query"] = "[]"
+LIST_REFERENCES_VALID_OPTIONS["--output-format"] = "json"
+
+
+@mock_backend(info_mock_output)
+def test_list_references_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(), list_references, LIST_REFERENCES_VALID_OPTIONS, blueprint_mock.run
+    )
+
+
+@mock_backend(info_mock_output)
+def test_list_references(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(list_references, ["--output-format", "json"], obj=obj)
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 2
+    assert {"Id": "ReferenceDataId[1]", "Type": "ReferenceType[1]"} in result
+    assert {"Id": "ReferenceDataId[2]", "Type": "ReferenceType[2]"} in result

--- a/tests/unit/command/layer/test_query.py
+++ b/tests/unit/command/layer/test_query.py
@@ -1,0 +1,164 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.reference import query_reference_types, query_references
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+info_mock_output = {
+    "ReferenceTypes": [
+        {
+            "Type": "ReferenceType[1]",
+            "Description": "ReferenceDescription[1]",
+            "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[1]",
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Description": "ReferenceDescription[2]",
+            "Attributes": [{"Names": "Attribute[2]", "Types": ["string"]}],
+            "PluralType": "ReferencePluralType[2]",
+        },
+    ],
+    "ReferenceData": [
+        {
+            "Type": "ReferenceType[1]",
+            "Id": "ReferenceDataId[1]",
+            "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+        },
+        {
+            "Type": "ReferenceType[2]",
+            "Id": "ReferenceDataId[2]",
+            "Properties": {"ReferenceProperty[2]": "ReferencePropertyValue[2]"},
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="info",
+        output_filename="info.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+QUERY_TYPES_VALID_OPTIONS = collections.OrderedDict()
+QUERY_TYPES_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_query_reference_types_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        query_reference_types,
+        QUERY_TYPES_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_query_reference_types(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        query_reference_types, ["--query", "[?Type==`ReferenceType[1]`]"], obj=obj
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 1
+    assert {
+        "Type": "ReferenceType[1]",
+        "Description": "ReferenceDescription[1]",
+        "Attributes": [{"Names": "Attribute[1]", "Types": ["string"]}],
+        "PluralType": "ReferencePluralType[1]",
+    } in result
+
+
+QUERY_REFERENCES_VALID_OPTIONS = collections.OrderedDict()
+QUERY_REFERENCES_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(info_mock_output)
+def test_query_references_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        query_references,
+        QUERY_REFERENCES_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(info_mock_output)
+def test_query_references(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        query_references,
+        ["--query", "[?Id==`ReferenceDataId[1]`]"],
+        obj=obj,
+    )
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 1
+    assert {
+        "Type": "ReferenceType[1]",
+        "Id": "ReferenceDataId[1]",
+        "Properties": {"ReferenceProperty[1]": "ReferencePropertyValue[1]"},
+    } in result


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for querying the available layer data
- Adds support for querying the component types that are available along with their attributes

## Motivation and Context

Makes it possible to query the resulting properties of layers and component types. To know what properties and data is available 

## How Has This Been Tested?

Tested locally and included test cases 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

