### PR TITLE
fix: quoting for shell params

### DIFF
--- a/hamlet/backend/common/runner.py
+++ b/hamlet/backend/common/runner.py
@@ -5,7 +5,6 @@ import shutil
 from hamlet.env import HAMLET_GLOBAL_CONFIG
 from .exceptions import BackendException
 
-
 def __cli_params_to_script_call(
     script_path,
     script_name,
@@ -22,7 +21,7 @@ def __cli_params_to_script_call(
             elif isinstance(value, tuple):
                 for instance in value:
                     options_list.append(str(key))
-                    options_list.append(str(instance))
+                    options_list.append(str(f"'{instance}'"))
             else:
                 options_list.append(str(key))
                 options_list.append(str(f"'{value}'"))

--- a/hamlet/backend/common/runner.py
+++ b/hamlet/backend/common/runner.py
@@ -5,6 +5,7 @@ import shutil
 from hamlet.env import HAMLET_GLOBAL_CONFIG
 from .exceptions import BackendException
 
+
 def __cli_params_to_script_call(
     script_path,
     script_name,

--- a/hamlet/command/run/task.py
+++ b/hamlet/command/run/task.py
@@ -8,23 +8,10 @@ from hamlet.command.common.config import pass_options
     "task", short_help="Run an ECS task", context_settings=dict(max_content_width=240)
 )
 @click.option(
-    "-c",
-    "--container-id",
-    help="name of the container that environment details are applied to",
-)
-@click.option(
-    "-d",
-    "--delay",
-    help="interval between checking the progress of the task",
-    type=click.INT,
-    default=30,
-    show_default=True,
-)
-@click.option(
-    "-e",
-    "--env",
-    "env_name",
-    help="name of an environment variable to define for the task",
+    "-t",
+    "--tier",
+    required=True,
+    help="name of the tier in the solution where the task is defined",
 )
 @click.option(
     "-i",
@@ -39,17 +26,6 @@ from hamlet.command.common.config import pass_options
     "-k", "--component-version", help="version of the ecs clsuter to run the task on"
 )
 @click.option(
-    "-t",
-    "--tier",
-    required=True,
-    help="name of the tier in the solution where the task is defined",
-)
-@click.option(
-    "-v",
-    "--value",
-    help="value for the last environment value defined (via -e) for the task",
-)
-@click.option(
     "-w",
     "--task",
     required=True,
@@ -57,6 +33,32 @@ from hamlet.command.common.config import pass_options
 )
 @click.option("-x", "--instance", help="instance of the task to be run")
 @click.option("-y", "--version", help="version of the task to be run")
+@click.option(
+    "-c",
+    "--container-id",
+    help="name of the container that environment details are applied to",
+)
+@click.option(
+    "-e",
+    "--env",
+    "env_name",
+    help="name of an environment variable to define for the task",
+    multiple=True,
+)
+@click.option(
+    "-v",
+    "--value",
+    help="value for the last environment value defined for the task",
+    multiple=True,
+)
+@click.option(
+    "-d",
+    "--delay",
+    help="interval between checking the progress of the task",
+    type=click.INT,
+    default=30,
+    show_default=True,
+)
 @exceptions.backend_handler()
 @pass_options
 def task(options, **kwargs):


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Ensure that options passed to bash scripts are quoted to ensure spaces aren't treated as breaks

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Running a script with a spaced option value in a list of multiple values would cause the script to fail

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

