### PR TITLE
feat: add entrance parameter support

### DIFF
--- a/hamlet/backend/create/template/__init__.py
+++ b/hamlet/backend/create/template/__init__.py
@@ -16,7 +16,7 @@ def run(
     generation_input_source=None,
     output_dir=None,
     disable_output_cleanup=None,
-    entrance_parameters=None,
+    entrance_parameter=None,
     log_level=None,
     root_dir=None,
     tenant=None,
@@ -42,7 +42,7 @@ def run(
         "-i": generation_input_source,
         "-o": output_dir,
         "-x": disable_output_cleanup,
-        "-y": entrance_parameters,
+        "-y": entrance_parameter,
     }
     env = {
         "GENERATION_LOG_LEVEL": log_level,

--- a/hamlet/backend/query/__init__.py
+++ b/hamlet/backend/query/__init__.py
@@ -15,6 +15,7 @@ def run(
     cwd,
     deployment_mode=None,
     generation_entrance=None,
+    generation_entrance_parameter=None,
     generation_input_source=None,
     generation_provider=None,
     generation_framework=None,
@@ -37,6 +38,7 @@ def run(
         cwd,
         deployment_mode=deployment_mode,
         generation_entrance=generation_entrance,
+        generation_entrance_parameter=generation_entrance_parameter,
         generation_input_source=generation_input_source,
         generation_provider=generation_provider,
         generation_framework=generation_framework,
@@ -50,10 +52,10 @@ def run(
         environment=environment,
         segment=segment,
     )
-    if query_text is not None:
-        result = query.query(query_text, query_params or {})
+    if query_text is None:
+        result = query.blueprint_data
     else:
-        raise exceptions.BackendException("Query unspecified")
+        result = query.query(query_text, query_params or {})
     if sub_query_text is not None:
         result = query.perform_query(sub_query_text, result)
     return result
@@ -65,6 +67,7 @@ class Query:
         cwd,
         deployment_mode,
         generation_entrance=None,
+        generation_entrance_parameter=None,
         generation_input_source=None,
         generation_provider=None,
         generation_framework=None,
@@ -96,6 +99,7 @@ class Query:
                 output_dir=output_dir,
                 deployment_mode=deployment_mode,
                 entrance=generation_entrance,
+                entrance_parameter=generation_entrance_parameter,
                 generation_input_source=generation_input_source,
                 generation_provider=generation_provider,
                 generation_framework=generation_framework,

--- a/hamlet/command/entrance/__init__.py
+++ b/hamlet/command/entrance/__init__.py
@@ -71,6 +71,12 @@ def list_entrances(options):
     required=True,
 )
 @click.option(
+    "-y",
+    "--entrance-parameter",
+    multiple=True,
+    help="key=value pairs that are passed to to the entrance",
+)
+@click.option(
     "-l",
     "--deployment-group",
     help="deployment group the deployment unit belongs to",

--- a/hamlet/command/schema/__init__.py
+++ b/hamlet/command/schema/__init__.py
@@ -126,7 +126,7 @@ def create_schemas(options, schema, output_dir, **kwargs):
             **options.opts,
             "entrance": "schema",
             "output_dir": output_dir,
-            "entrance_parameters": f"Schema={schema_task['Schema']}",
+            "entrance_parameter": f"Schema={schema_task['Schema']}",
         }
 
         create_template_backend.run(**template_args, _is_cli=True)

--- a/tests/unit/command/component/test_component_types.py
+++ b/tests/unit/command/component/test_component_types.py
@@ -33,6 +33,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/component/test_occurrence.py
+++ b/tests/unit/command/component/test_occurrence.py
@@ -15,6 +15,7 @@ from hamlet.command.component.common import DescribeContext
 def template_backend_run_mock(data):
     def run(
         entrance="occurrences",
+        entrance_parameter=None,
         output_filename="occurrences-state.json",
         output_dir=None,
         deployment_mode=None,

--- a/tests/unit/command/deploy/test_deploy.py
+++ b/tests/unit/command/deploy/test_deploy.py
@@ -27,6 +27,7 @@ ALL_VALID_OPTIONS["--dryrun"] = True
 def template_backend_run_mock(data):
     def run(
         entrance="unitlist",
+        entrance_parameter=None,
         output_filename="unitlist-managementcontract.json",
         deployment_mode=None,
         output_dir=None,
@@ -56,7 +57,12 @@ def mock_backend(unitlist=None):
         @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
         def wrapper(
-            blueprint_mock, ContextClassMock, create_template_backend, *args, **kwargs
+            blueprint_mock,
+            ContextClassMock,
+            create_deployment_backend,
+            run_deployment_backend,
+            *args,
+            **kwargs
         ):
             with tempfile.TemporaryDirectory() as temp_cache_dir:
 
@@ -71,7 +77,8 @@ def mock_backend(unitlist=None):
                 return func(
                     blueprint_mock,
                     ContextClassMock,
-                    create_template_backend,
+                    create_deployment_backend,
+                    run_deployment_backend,
                     *args,
                     **kwargs
                 )
@@ -116,7 +123,7 @@ unit_list = {
 
 @mock_backend(unit_list)
 def test_input_valid(
-    blueprint_mock, ContextClassMock, create_template_backend, manage_stack_backend
+    blueprint_mock, ContextClassMock, create_deployment_backend, run_deployment_backend
 ):
     run_options_test(
         CliRunner(), run_deployments, ALL_VALID_OPTIONS, blueprint_mock.run
@@ -125,13 +132,13 @@ def test_input_valid(
 
 @mock_backend(unit_list)
 def test_input_validation(
-    blueprint_mock, ContextClassMock, create_template_backend, manage_stack_backend
+    blueprint_mock, ContextClassMock, create_deployment_backend, run_deployment_backend
 ):
     runner = CliRunner()
     run_validatable_option_test(
         runner,
         run_deployments,
-        create_template_backend.run,
+        create_deployment_backend.run,
         {
             "-m": "DeploymentMode1",
             "-l": "DeploymentGroup1",

--- a/tests/unit/command/deploy/test_list.py
+++ b/tests/unit/command/deploy/test_list.py
@@ -10,6 +10,7 @@ from hamlet.command.deploy.list import list_deployments
 def template_backend_run_mock(data):
     def run(
         entrance="unitlist",
+        entrance_parameter=None,
         deployment_mode="update",
         output_filename="unitlist-managementcontract.json",
         output_dir=None,

--- a/tests/unit/command/deploy/test_test.py
+++ b/tests/unit/command/deploy/test_test.py
@@ -25,6 +25,7 @@ ALL_VALID_OPTIONS["-s,--silent"] = False
 def template_backend_run_mock(data):
     def run(
         entrance="unitlist",
+        entrance_parameter=None,
         output_filename="unitlist-managementcontract.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/entrance/test_invoke.py
+++ b/tests/unit/command/entrance/test_invoke.py
@@ -11,6 +11,7 @@ from tests.unit.command.test_option_generation import (
 ALL_VALID_OPTIONS = collections.OrderedDict()
 
 ALL_VALID_OPTIONS["!-e,--entrance"] = "entrance"
+ALL_VALID_OPTIONS["-y,--entrance-parameter"] = "entrance_parameter"
 ALL_VALID_OPTIONS["-l,--deployment-group"] = "deployment_group"
 ALL_VALID_OPTIONS["-u,--deployment-unit"] = "deployment_unit"
 ALL_VALID_OPTIONS["-z,--deployment-unit-subset"] = "deployment_unit_subset"

--- a/tests/unit/command/entrance/test_list.py
+++ b/tests/unit/command/entrance/test_list.py
@@ -10,6 +10,7 @@ from hamlet.command.entrance import list_entrances as list_entrances
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         output_dir=None,
         generation_input_source=None,

--- a/tests/unit/command/layer/test_describe.py
+++ b/tests/unit/command/layer/test_describe.py
@@ -49,6 +49,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/layer/test_list.py
+++ b/tests/unit/command/layer/test_list.py
@@ -49,6 +49,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/layer/test_query.py
+++ b/tests/unit/command/layer/test_query.py
@@ -48,6 +48,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/reference/test_describe.py
+++ b/tests/unit/command/reference/test_describe.py
@@ -47,6 +47,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/reference/test_list.py
+++ b/tests/unit/command/reference/test_list.py
@@ -47,6 +47,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/reference/test_query.py
+++ b/tests/unit/command/reference/test_query.py
@@ -46,6 +46,7 @@ info_mock_output = {
 def template_backend_run_mock(data):
     def run(
         entrance="info",
+        entrance_parameter=None,
         output_filename="info.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/schema/test_create.py
+++ b/tests/unit/command/schema/test_create.py
@@ -20,6 +20,7 @@ ALL_VALID_OPTIONS["-s,--schema"] = "Schema1"
 def template_backend_run_mock(data):
     def run(
         entrance="schemalist",
+        entrance_parameter=None,
         output_filename="schemalist-schemacontract.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/schema/test_list.py
+++ b/tests/unit/command/schema/test_list.py
@@ -12,6 +12,7 @@ from hamlet.command.common.config import Options
 def template_backend_run_mock(data):
     def run(
         entrance="schemalist",
+        entrance_parameter=None,
         output_filename="schemalist-schemacontract.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/visual/test_draw.py
+++ b/tests/unit/command/visual/test_draw.py
@@ -23,6 +23,7 @@ ALL_VALID_OPTIONS["-s,--src-dir"] = "./"
 def template_backend_run_mock(data):
     def run(
         entrance="diagraminfo",
+        entrance_parameter=None,
         output_filename="diagraminfo.json",
         deployment_mode=None,
         output_dir=None,

--- a/tests/unit/command/visual/test_list.py
+++ b/tests/unit/command/visual/test_list.py
@@ -13,6 +13,7 @@ from hamlet.command.visual import list_diagram_types as list_diagram_types
 def template_backend_run_mock(data):
     def run(
         entrance="diagraminfo",
+        entrance_parameter=None,
         output_filename="diagraminfo.json",
         output_dir=None,
         generation_input_source=None,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for providing entrance parameters to create template
- Updates testing to support new args for create template
- refactors some of the deploy testing to test appropriate task calls

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
More entrances are now using the entrance parameters instead of overloading the deployment Unit and Group standard entrance parameters. This allows for the cli to support these entrances

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

