### PR TITLE
feat: add support for runbook execution through cli

### DIFF
--- a/hamlet/__init__.py
+++ b/hamlet/__init__.py
@@ -15,5 +15,6 @@ import hamlet.command.release  # noqa
 import hamlet.command.run  # noqa
 import hamlet.command.schema  # noqa
 import hamlet.command.setup  # noqa
+import hamlet.command.task  # noqa
 import hamlet.command.test  # noqa
 import hamlet.command.visual  # noqa

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -30,7 +30,7 @@ except ImportError:
 @backend_handler()
 def root(ctx, opts):
     """
-    hamlet deploy
+    hamlet
     """
 
     try:

--- a/hamlet/command/task/__init__.py
+++ b/hamlet/command/task/__init__.py
@@ -1,0 +1,159 @@
+import click
+import os
+import json
+from tabulate import tabulate
+
+from hamlet.command.common.display import json_or_table_option, wrap_text
+from hamlet.command import root as cli
+from hamlet.command.common import exceptions
+from hamlet.command.common.config import pass_options
+from hamlet.backend import query as query_backend
+from hamlet.backend import contract as contract_backend
+
+
+def query_runbookinfo_state(options, query, query_params=None, sub_query_text=None):
+
+    query_args = {
+        **options.opts,
+        "generation_entrance": "runbookinfo",
+        "output_filename": "runbookinfo-config.json",
+        "use_cache": False,
+    }
+    query_result = query_backend.run(
+        **query_args,
+        cwd=os.getcwd(),
+        query_text=query,
+        query_params=query_params,
+        sub_query_text=sub_query_text,
+    )
+
+    return query_result
+
+
+LIST_RUNBOOKS_QUERY = (
+    "RunBooks[]" ".{" "Name:Name," "Description:Description," "Engine:Engine" "}"
+)
+
+DESCRIBE_RUNBOOK_QUERY = "RunBooks[?Name=={name}] | [0]"
+
+
+def list_runbooks_table(data):
+    tablerows = []
+    for row in data:
+        tablerows.append(
+            [
+                wrap_text(row["Name"]),
+                wrap_text(row["Description"]),
+                wrap_text(row["Engine"]),
+            ]
+        )
+    return tabulate(
+        tablerows,
+        headers=[
+            "Name",
+            "Description",
+            "Engine",
+        ],
+        tablefmt="github",
+    )
+
+
+@cli.group("task", context_settings=dict(max_content_width=240))
+def group():
+    """
+    Runs tasks against a hamlet deployment
+    """
+
+
+@group.command(
+    "list-runbooks", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-q", "--query", help="A JMESPath query to apply to the results")
+@json_or_table_option(list_runbooks_table)
+@exceptions.backend_handler()
+@pass_options
+def list_runbooks(options, query, **kwargs):
+    """
+    List available runbooks
+    """
+    return query_runbookinfo_state(
+        options=options, query=LIST_RUNBOOKS_QUERY, sub_query_text=query
+    )
+
+
+@group.command(
+    "describe-runbook", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option("-n", "--name", required=True, help="The name of the runbook to describe")
+@click.option("-q", "--query", help="A JMESPath query to apply to the results")
+@exceptions.backend_handler()
+@pass_options
+def describe_runbook(options, name, query=None, **kwargs):
+    """
+    Describe a specific runbook
+    """
+
+    result = query_runbookinfo_state(
+        options=options,
+        query=DESCRIBE_RUNBOOK_QUERY,
+        query_params={"name": name},
+        sub_query_text=query,
+    )
+    click.echo(json.dumps(result, indent=4))
+
+
+@group.command(
+    "run-runbook", short_help="", context_settings=dict(max_content_width=240)
+)
+@click.option(
+    "-n",
+    "--name",
+    required=True,
+    help="The name of a runbook to execute",
+)
+@click.option(
+    "--confirm/--no-confirm",
+    default=False,
+    help="Confirm before starting the runbook",
+)
+@click.argument("parameters", nargs=-1)
+@exceptions.backend_handler()
+@pass_options
+def run_runbook(options, name, confirm, parameters, **kwargs):
+    """
+    Run a runbook
+    """
+
+    parameters = dict([arg.split("=") for arg in parameters])
+
+    runbook_description = query_runbookinfo_state(
+        options=options,
+        query=DESCRIBE_RUNBOOK_QUERY,
+        query_params={"name": name},
+    )
+
+    if runbook_description is None:
+        raise exceptions.CommandError("No runbooks found with the provided name")
+
+    click.echo("")
+    click.secho(f"[*] {name}", bold=True, fg="green")
+    if runbook_description["Description"] != "":
+        click.secho(
+            f"[*]   {runbook_description['Description']}", bold=True, fg="green"
+        )
+    click.echo("")
+
+    if (confirm and click.confirm("Start Runbook?")) or not confirm:
+
+        query_args = {
+            **options.opts,
+            "generation_entrance": "runbook",
+            "generation_entrance_parameter": (
+                f"RunBook={name}",
+                f"RunBookInputs={json.dumps(parameters)}",
+            ),
+            "output_filename": "runbook-contract.json",
+            "use_cache": False,
+        }
+        contract = query_backend.run(**query_args, cwd=os.getcwd(), query=None)
+        contract_backend.run(contract)

--- a/tests/unit/command/task/test_describe.py
+++ b/tests/unit/command/task/test_describe.py
@@ -1,0 +1,115 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.task import describe_runbook
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+runbookinfo_mock_output = {
+    "RunBooks": [
+        {
+            "Name": "RunBook1",
+            "Description": "RunBookDescription1",
+            "Engine": "RunBookEngine1",
+        },
+        {
+            "Name": "RunBook2",
+            "Description": "RunBookDescription2",
+            "Engine": "RunBookEngine2",
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="runbookinfo",
+        entrance_parameter=None,
+        output_filename="runbookinfo-config.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+DECSCRIBE_RUNBOOK_VALID_OPTIONS = collections.OrderedDict()
+DECSCRIBE_RUNBOOK_VALID_OPTIONS["!-n,--name"] = "RunBook1"
+DECSCRIBE_RUNBOOK_VALID_OPTIONS["-q,--query"] = "[]"
+
+
+@mock_backend(runbookinfo_mock_output)
+def test_describe_runbook_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(),
+        describe_runbook,
+        DECSCRIBE_RUNBOOK_VALID_OPTIONS,
+        blueprint_mock.run,
+    )
+
+
+@mock_backend(runbookinfo_mock_output)
+def test_describe_runbook(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(
+        describe_runbook,
+        ["--name", "RunBook1"],
+        obj=obj,
+    )
+    print(result.output)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert {
+        "Name": "RunBook1",
+        "Description": "RunBookDescription1",
+        "Engine": "RunBookEngine1",
+    } == result

--- a/tests/unit/command/task/test_list.py
+++ b/tests/unit/command/task/test_list.py
@@ -1,0 +1,114 @@
+import os
+import hashlib
+import json
+import tempfile
+import collections
+
+from unittest import mock
+from click.testing import CliRunner
+
+from hamlet.command.task import list_runbooks
+from hamlet.command.common.config import Options
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+)
+
+
+runbookinfo_mock_output = {
+    "RunBooks": [
+        {
+            "Name": "RunBook[1]",
+            "Description": "RunBookDescription[1]",
+            "Engine": "RunBookEngine[1]",
+        },
+        {
+            "Name": "RunBook[2]",
+            "Description": "RunBookDescription[2]",
+            "Engine": "RunBookEngine[2]",
+        },
+    ],
+}
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance="runbookinfo",
+        entrance_parameter=None,
+        output_filename="runbookinfo-config.json",
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
+            json.dump(data, f)
+
+    return run
+
+
+def mock_backend(data=None):
+    def decorator(func):
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(data).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+                blueprint_mock.run.side_effect = template_backend_run_mock(data)
+
+                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+LIST_RUNBOOKS_VALID_OPTIONS = collections.OrderedDict()
+LIST_RUNBOOKS_VALID_OPTIONS["-q,--query"] = "[]"
+LIST_RUNBOOKS_VALID_OPTIONS["--output-format"] = "json"
+
+
+@mock_backend(runbookinfo_mock_output)
+def test_list_runbooks_input_valid(
+    blueprint_mock,
+    ContextClassMock,
+):
+    run_options_test(
+        CliRunner(), list_runbooks, LIST_RUNBOOKS_VALID_OPTIONS, blueprint_mock.run
+    )
+
+
+@mock_backend(runbookinfo_mock_output)
+def test_list_runbooks(blueprint_mock, ContextClassMock):
+    obj = Options()
+
+    cli = CliRunner()
+    result = cli.invoke(list_runbooks, ["--output-format", "json"], obj=obj)
+    print(result.exc_info)
+    assert result.exit_code == 0
+    result = json.loads(result.output)
+    assert len(result) == 2
+    assert {
+        "Name": "RunBook[1]",
+        "Description": "RunBookDescription[1]",
+        "Engine": "RunBookEngine[1]",
+    } in result
+    assert {
+        "Name": "RunBook[2]",
+        "Description": "RunBookDescription[2]",
+        "Engine": "RunBookEngine[2]",
+    } in result

--- a/tests/unit/command/task/test_run.py
+++ b/tests/unit/command/task/test_run.py
@@ -1,0 +1,114 @@
+import collections
+import tempfile
+import hashlib
+import json
+import os
+
+from unittest import mock
+from click.testing import CliRunner
+from hamlet.command.task import run_runbook
+from tests.unit.command.test_option_generation import (
+    run_options_test,
+    run_validatable_option_test,
+)
+
+ALL_VALID_OPTIONS = collections.OrderedDict()
+ALL_VALID_OPTIONS["!-n,--name"] = "RunBook1"
+ALL_VALID_OPTIONS["--confirm"] = False
+ALL_VALID_OPTIONS["--"] = "test=true"
+
+
+def template_backend_run_mock(data):
+    def run(
+        entrance=None,
+        entrance_parameter=None,
+        output_filename=None,
+        deployment_mode=None,
+        output_dir=None,
+        generation_input_source=None,
+        generation_provider=None,
+        generation_framework=None,
+        log_level=None,
+        root_dir=None,
+        tenant=None,
+        account=None,
+        product=None,
+        environment=None,
+        segment=None,
+    ):
+        for set in data:
+            os.makedirs(output_dir, exist_ok=True)
+            filename = os.path.join(output_dir, set[2])
+            with open(filename, "wt+") as f:
+                json.dump(set[0], f)
+
+    return run
+
+
+def mock_backend(runbookinfo=None, contract=None):
+    def decorator(func):
+        @mock.patch("hamlet.command.task.contract_backend")
+        @mock.patch("hamlet.backend.query.context.Context")
+        @mock.patch("hamlet.backend.query.template")
+        def wrapper(
+            blueprint_mock, ContextClassMock, contract_backend, *args, **kwargs
+        ):
+            with tempfile.TemporaryDirectory() as temp_cache_dir:
+
+                ContextObjectMock = ContextClassMock()
+                ContextObjectMock.md5_hash.return_value = str(
+                    hashlib.md5(str(runbookinfo).encode()).hexdigest()
+                )
+                ContextObjectMock.cache_dir = temp_cache_dir
+
+                blueprint_mock.run.side_effect = template_backend_run_mock(
+                    [
+                        (runbookinfo, "runbookinfo", "runbookinfo-config.json"),
+                        (contract, "runbook", "runbook-contract.json"),
+                    ]
+                )
+
+                return func(
+                    blueprint_mock, ContextClassMock, contract_backend, *args, **kwargs
+                )
+
+        return wrapper
+
+    return decorator
+
+
+runbookinfo_mock_output = {
+    "RunBooks": [
+        {
+            "Name": "RunBook1",
+            "Description": "RunBookDescription1",
+            "Engine": "RunBookEngine1",
+        },
+        {
+            "Name": "RunBook2",
+            "Description": "RunBookDescription2",
+            "Engine": "RunBookEngine2",
+        },
+    ],
+}
+
+runbook_mock_output = {"Stages": [{"Id": "Stage1", "Steps": [{"Id": "Step1"}]}]}
+
+
+@mock_backend(runbookinfo_mock_output, runbook_mock_output)
+def test_input_valid(blueprint_mock, ContextClassMock, contract_backend):
+    run_options_test(CliRunner(), run_runbook, ALL_VALID_OPTIONS, contract_backend.run)
+
+
+@mock_backend(runbookinfo_mock_output, runbook_mock_output)
+def test_input_validation(blueprint_mock, ContextClassMock, contract_backend):
+    runner = CliRunner()
+    run_validatable_option_test(
+        runner,
+        run_runbook,
+        contract_backend.run,
+        {
+            "-n": "RunBook1",
+        },
+        [],
+    )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the task command group for task and contract related activities
- Adds runbook execution and listing of runbooks
- Adds testing for the commands

The runbook name is based on the RawTypedName of the run book with runbook inputs provided through space separated key value arguments 

```bash
hamlet task run-runbook -n my-runbook runbookInput1="this" runbookInput2="that" 
```

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for generating and running runbooks through the hamlet cli which makes them easy to discover and run 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/executor-python/pull/276

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

