### PR TITLE
fix: engine override install process

### DIFF
--- a/hamlet/backend/engine/__init__.py
+++ b/hamlet/backend/engine/__init__.py
@@ -60,22 +60,26 @@ class EngineStore:
         Setting the global engine will locate the provided engine then update
         its symlinks to point to the provided engine.
         """
-        global_engine = self.get_engine(ENGINE_GLOBAL_NAME)
-        engine = self.get_engine(name)
+        if name is None:
+            self._global_engine = None
 
-        for type, path in global_engine.part_paths.items():
-            if os.path.islink(path):
-                os.unlink(path)
+        else:
+            global_engine = self.get_engine(ENGINE_GLOBAL_NAME)
+            engine = self.get_engine(name)
 
-            if os.path.isdir(path):
-                os.rmdir(path)
+            for type, path in global_engine.part_paths.items():
+                if os.path.islink(path):
+                    os.unlink(path)
 
-            if engine.part_paths.get(type, None):
-                os.symlink(engine.part_paths[type], path, target_is_directory=True)
-            else:
-                os.makedirs(path)
+                if os.path.isdir(path):
+                    os.rmdir(path)
 
-        self._global_engine = engine.name
+                if engine.part_paths.get(type, None):
+                    os.symlink(engine.part_paths[type], path, target_is_directory=True)
+                else:
+                    os.makedirs(path)
+
+            self._global_engine = engine.name
 
         self.store_state = {"global_engine": self.global_engine}
         self.save_store_state()

--- a/hamlet/command/__init__.py
+++ b/hamlet/command/__init__.py
@@ -41,5 +41,8 @@ def root(ctx, opts):
     except OSError as e:
         raise HamletHomeDirUnavailableException(str(e))
 
-    setup_global_engine(opts.engine)
-    get_engine_env(opts.engine)
+    # Pass the global engine setup to the engine command
+    # so we can skip it for certain commands
+    if ctx.invoked_subcommand != "engine":
+        setup_global_engine(opts.engine)
+        get_engine_env(opts.engine)

--- a/tests/unit/command/engine/test_engine.py
+++ b/tests/unit/command/engine/test_engine.py
@@ -47,9 +47,6 @@ def mock_backend():
 
             mock_engine_store.get_engines.return_value = mock_engines
             mock_engine_store.find_engines.return_value = mock_engines
-            type(mock_engine_store).global_engine = mock.PropertyMock(
-                return_value="Name[2]"
-            )
 
             return func(mock_engine_store, *args, **kwargs)
 
@@ -72,7 +69,6 @@ def test_list_engines(mock_engine_store):
         "description": "Description[1]",
         "digest": "",
         "installed": False,
-        "global": False,
         "update_available": None,
     } in result
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Handles installing an engine defined through the override process
- Adds either argument or option for install engines
- Add global engine unset if engines are cleaned
- Fix digest details in engine install

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
In CI pipelines its common to set a global variable in the pipeline for configuration options. In hamlet you can set the engine this way using the HAMLET_ENGINE var, however if you are installing the engine you have set after setting this variable an error is raised that its not installed. 

This fixes that infinite loop problem and allows for installing engines which aren't available when an engine override is set.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

