### PR TITLE
feat(contract): add kms encryption tasks

### DIFF
--- a/hamlet/backend/contract/__init__.py
+++ b/hamlet/backend/contract/__init__.py
@@ -1,20 +1,23 @@
 import importlib
+import click
 from hamlet.backend.contract.tasks.exceptions import (
     TaskConditionFailureException,
     TaskFailureException,
 )
 
 
-def run(contract, **kwargs):
+def run(contract, silent, **kwargs):
 
     properties = contract["Properties"]
 
     for stage in contract["Stages"]:
 
-        print(f"[-] Running contract stage {stage['Id']}")
+        if not silent:
+            click.echo(f"\n[-] Running contract stage {stage['Id']}")
 
         for step in stage["Steps"]:
-            print(f"      Step: {step['Id']} - Task: {step['Type']}")
+            if not silent:
+                click.echo(f"      Step: {step['Id']} - Task: {step['Type']}")
 
             try:
                 task = importlib.import_module(

--- a/hamlet/backend/contract/tasks/aws_ecs_run_command/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_ecs_run_command/__init__.py
@@ -75,4 +75,4 @@ def run(
         region_name=Region,
     )
 
-    return {}
+    return {"Properties": {}}

--- a/hamlet/backend/contract/tasks/aws_kms_decrypt_ciphertext/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_kms_decrypt_ciphertext/__init__.py
@@ -4,8 +4,7 @@ from base64 import b64decode
 
 def run(
     Ciphertext,
-    Base64Encoded,
-    EncryptionScheme,
+    EncryptionScheme=None,
     Region=None,
     AWSAccessKeyId=None,
     AWSSecretAccessKey=None,
@@ -13,16 +12,13 @@ def run(
     env={},
 ):
     """
-    Given an aws kms ciphertext blob decrypt it using the provided
-    credentials and return the plaintext result as a string
+    Given a base64 encoded aws kms ciphertext blob decrypt it using
+    the provided credentials and return the plaintext result as a string
     """
 
-    if Base64Encoded is True:
-        if EncryptionScheme != "":
-            Ciphertext = Ciphertext.replace(EncryptionScheme, "", 1)
-        Ciphertext = b64decode(Ciphertext)
-    else:
-        Ciphertext = bytes(Ciphertext)
+    if EncryptionScheme != "":
+        Ciphertext = Ciphertext.replace(EncryptionScheme, "", 1)
+    Ciphertext = b64decode(Ciphertext)
 
     session = boto3.Session(
         aws_access_key_id=AWSAccessKeyId,

--- a/hamlet/backend/contract/tasks/aws_kms_encrypt_value/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_kms_encrypt_value/__init__.py
@@ -1,0 +1,37 @@
+import boto3
+from base64 import b64encode
+
+
+def run(
+    KeyArn,
+    Value,
+    EncryptionScheme="",
+    Region=None,
+    AWSAccessKeyId=None,
+    AWSSecretAccessKey=None,
+    AWSSessionToken=None,
+    env={},
+):
+    """
+    Given a string use aws kms to encrypt the string and return the value
+    as a base64 encoded string of the ciphertext blog as the result
+    """
+
+    session = boto3.Session(
+        aws_access_key_id=AWSAccessKeyId,
+        aws_secret_access_key=AWSSecretAccessKey,
+        aws_session_token=AWSSessionToken,
+        region_name=Region,
+    )
+
+    kms = session.client("kms")
+    result = kms.encrypt(
+        KeyId=KeyArn,
+        Plaintext=bytes(Value, "utf-8"),
+    )
+
+    return {
+        "Properties": {
+            "result": f"{EncryptionScheme}{b64encode(result['CiphertextBlob']).decode('utf-8')}"
+        }
+    }

--- a/hamlet/backend/contract/tasks/conditional_stage_skip/__init__.py
+++ b/hamlet/backend/contract/tasks/conditional_stage_skip/__init__.py
@@ -17,6 +17,6 @@ def run(Condition, Test, Value, env={}):
         result = Value.contains(Test)
 
     if not result:
-        raise TaskConditionFailureException()
+        raise TaskConditionFailureException("Condition not met")
 
     return {"Properties": {"result": result}}

--- a/hamlet/backend/contract/tasks/file_read_content/__init__.py
+++ b/hamlet/backend/contract/tasks/file_read_content/__init__.py
@@ -1,0 +1,16 @@
+from hamlet.backend.common.exceptions import BackendException
+
+
+def run(FilePath, env={}):
+    """
+    read the content of a given filepath and return it as the result
+    """
+    content = ""
+    try:
+        with open(FilePath, "r") as file:
+            content = file.read()
+
+    except FileNotFoundError as e:
+        raise BackendException(str(e))
+
+    return {"Properties": {"result": content}}

--- a/hamlet/backend/contract/tasks/output_echo/__init__.py
+++ b/hamlet/backend/contract/tasks/output_echo/__init__.py
@@ -1,0 +1,15 @@
+import json
+import click
+
+
+def run(Value, Format, OutputStream, env={}):
+    """
+    echo a given value to an output stream
+    """
+
+    err = OutputStream == "stderr"
+    if Format == "json":
+        Value = json.dumps(json.loads(Value), indent=2)
+
+    click.echo(Value, err=err)
+    return {"Properties": {"result": Value}}

--- a/hamlet/command/common/validate.py
+++ b/hamlet/command/common/validate.py
@@ -1,0 +1,14 @@
+import click
+
+
+def validate_entrance_inputs(ctx, param, value):
+    """
+    Custom validation for entrance inputs which are provided as Key=Value
+    strings
+    """
+    try:
+        value = dict([arg.split("=", 1) for arg in value])
+    except ValueError:
+        raise click.BadParameter("input arguments must be in 'Key=Value' format")
+
+    return value

--- a/hamlet/command/entrance/__init__.py
+++ b/hamlet/command/entrance/__init__.py
@@ -8,6 +8,7 @@ from hamlet.command import root as cli
 from hamlet.command.common.display import json_or_table_option, wrap_text
 from hamlet.command.common import exceptions
 from hamlet.command.common.config import pass_options
+from hamlet.command.common.validate import validate_entrance_inputs
 from hamlet.backend.create import template as create_template_backend
 from hamlet.backend import query as query_backend
 
@@ -75,6 +76,7 @@ def list_entrances(options):
     "--entrance-parameter",
     multiple=True,
     help="key=value pairs that are passed to to the entrance",
+    callback=validate_entrance_inputs,
 )
 @click.option(
     "-l",

--- a/tests/unit/command/entrance/test_invoke.py
+++ b/tests/unit/command/entrance/test_invoke.py
@@ -11,7 +11,7 @@ from tests.unit.command.test_option_generation import (
 ALL_VALID_OPTIONS = collections.OrderedDict()
 
 ALL_VALID_OPTIONS["!-e,--entrance"] = "entrance"
-ALL_VALID_OPTIONS["-y,--entrance-parameter"] = "entrance_parameter"
+ALL_VALID_OPTIONS["-y,--entrance-parameter"] = "entrance_parameter=1"
 ALL_VALID_OPTIONS["-l,--deployment-group"] = "deployment_group"
 ALL_VALID_OPTIONS["-u,--deployment-unit"] = "deployment_unit"
 ALL_VALID_OPTIONS["-z,--deployment-unit-subset"] = "deployment_unit_subset"

--- a/tests/unit/command/task/test_run.py
+++ b/tests/unit/command/task/test_run.py
@@ -15,6 +15,7 @@ from tests.unit.command.test_option_generation import (
 ALL_VALID_OPTIONS = collections.OrderedDict()
 ALL_VALID_OPTIONS["!-n,--name"] = "RunBook1"
 ALL_VALID_OPTIONS["--confirm"] = False
+ALL_VALID_OPTIONS["--silent"] = False
 ALL_VALID_OPTIONS["--"] = "test=true"
 
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds new contract tasks to handle encryption of values using kms and support for echoing output from other results
- fixes an issue in using conditional tasks
- Adds support for silent output on runbooks to only capture the output from tasks instead of extra details that show what the runbook is doing
- Adds validation of runbook parameters to split inputs on the first = only

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for the replacement of the current bash based scripts for encryption and allows for these to be included in custom runbooks as required.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

