### PR TITLE
fix: initial engine loading missing engine

### DIFF
--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -40,7 +40,9 @@ def setup_global_engine(engine_override):
     if engine_store.global_engine is None:
 
         default_engine = (
-            engine_override if engine_override is not None else ENGINE_DEFAULT_GLOBAL_ENGINE
+            engine_override
+            if engine_override is not None
+            else ENGINE_DEFAULT_GLOBAL_ENGINE
         )
 
         try:

--- a/hamlet/command/common/engine_setup.py
+++ b/hamlet/command/common/engine_setup.py
@@ -40,7 +40,7 @@ def setup_global_engine(engine_override):
     if engine_store.global_engine is None:
 
         default_engine = (
-            engine_override if engine_override else ENGINE_DEFAULT_GLOBAL_ENGINE
+            engine_override if engine_override is not None else ENGINE_DEFAULT_GLOBAL_ENGINE
         )
 
         try:
@@ -51,6 +51,7 @@ def setup_global_engine(engine_override):
             engine_store.get_engine(
                 default_engine, locations=["local", "remote", "hidden"]
             ).install()
+            engine_store.load_engines(locations=["installed"], refresh=True)
 
         engine_store.global_engine = default_engine
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes an issue where an engine installed as part of setting the default engine isn't found by the command running it

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When an engine override is provided and no engines have been set as the global engine, the engine is automatically installed and setup. However  the available engines wern't being refreshed which meant that environment lookup was failing to find the engine.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

