### PR TITLE
fix: engine name provided to install-engine

### DIFF
--- a/hamlet/command/engine/__init__.py
+++ b/hamlet/command/engine/__init__.py
@@ -255,7 +255,7 @@ def install_engine(options, name, location, update):
     options.engine_store.load_engines(locations=location, refresh=True)
 
     if name is None and options.engine:
-        name = options.engine
+        name = options.engine.name
 
     if name is None:
         raise click.exceptions.BadParameter(


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- when an engine name isn't provided to the install-engine command it falls back to an engine provided via the root options
- When this happens the name of the engine needs to be provided instead of the engine itself

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Command failing when running hamlet engine install-engine without the engine name provided as an argument

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
TEsted locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

