### PR TITLE
fix: extend read timeout for container image handling

### DIFF
--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -10,15 +10,19 @@ import json
 
 from urllib import parse
 
-
+timeout = httpx.Timeout(timeout=5.0, read=120.0)
 transport = httpx.HTTPTransport(retries=3)
+
 container_httpx_client = httpx.Client(
     headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
     follow_redirects=True,
     transport=transport,
+    timeout=timeout
 )
 
-auth_httpx_client = httpx.Client(transport=transport)
+auth_httpx_client = httpx.Client(
+    transport=transport,
+)
 
 
 class ContainerRepositoryException(BaseException):

--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -17,7 +17,7 @@ container_httpx_client = httpx.Client(
     headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
     follow_redirects=True,
     transport=transport,
-    timeout=timeout
+    timeout=timeout,
 )
 
 auth_httpx_client = httpx.Client(


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- tight read timeout is used by default for httpx clients
- extending the timeout ensures we don't get read time out errors

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Timeouts on downloading the large engine container images

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

