### PR TITLE
fix: use full engine-core image

### DIFF
--- a/hamlet/backend/engine/loaders/unicycle.py
+++ b/hamlet/backend/engine/loaders/unicycle.py
@@ -1,5 +1,4 @@
 import typing
-import platform
 
 from hamlet.backend.engine.engine_loader import EngineLoader
 
@@ -55,7 +54,7 @@ class UnicycleEngineLoader(EngineLoader):
                 description="hamlet freemarker wrapper",
                 registry_url="https://ghcr.io",
                 repository="hamlet-io/engine-core",
-                tag=f"edge-{platform.system()}",
+                tag="edge",
             ),
         ]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Reverts to using the full engine-core image instead of the platform specific image

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
At the moment the unicycle engine feeds the tram engine which feeds the train engine. So in order to ensure that the tram and train releases contain all possible platforms in their images we need to include all platforms in the unicycle build. 

This can be revisited in the future to work with an potential performance issues. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

