### PR TITLE
feat: add bundled shim engine loader

### DIFF
--- a/hamlet/backend/engine/__init__.py
+++ b/hamlet/backend/engine/__init__.py
@@ -4,7 +4,8 @@ import json
 
 from .exceptions import EngineStoreMissingEngineException
 
-from .loaders.base import ShimEngineLoader, InstalledEngineLoader
+from .loaders.base import InstalledEngineLoader
+from .loaders.shim import ShimEngineLoader, BundledShimEngineLoader
 from .loaders.unicycle import UnicycleEngineLoader
 from .loaders.tram import LatestTramEngineLoader, TramEngineLoader
 from .loaders.train import LatestTrainEngineLoader, TrainEngineLoader
@@ -46,6 +47,7 @@ class EngineStore:
                 "description": "Local user defined engines that are available",
                 "loaders": [
                     ShimEngineLoader(),
+                    BundledShimEngineLoader(),
                     UserDefinedEngineLoader(
                         config_search_paths=self.config_search_paths
                     ),

--- a/hamlet/backend/engine/loaders/shim.py
+++ b/hamlet/backend/engine/loaders/shim.py
@@ -1,0 +1,79 @@
+import typing
+
+from hamlet.backend.engine.engine_loader import EngineLoader
+
+from hamlet.backend.engine.engine import Engine, ShimEngine
+from hamlet.backend.engine.engine_part import (
+    CoreEnginePart,
+    AWSEnginePluginPart,
+    AzureEnginePluginPart,
+    CMDBEnginePluginPart,
+    BashExecutorEnginePart,
+    WrapperEnginePart,
+    BundledWrapperEnginePart
+)
+from hamlet.backend.engine.engine_source import ShimPathEngineSource
+
+
+class ShimEngineLoader(EngineLoader):
+    """
+    Seeds an engine used to create a known engine directory that can be used to establish
+    a standard location for hamlet scripts called outside of the cli
+    """
+
+    def load(self) -> typing.Iterable[Engine]:
+        engine_source = [
+            ShimPathEngineSource(name="shim", description="shim based root dir source")
+        ]
+
+        engine_parts = [
+            CoreEnginePart(source_path="engine-core", source_name="shim"),
+            BashExecutorEnginePart(source_path="executor-bash", source_name="shim"),
+            AWSEnginePluginPart(source_path="engine-plugin-aws", source_name="shim"),
+            AzureEnginePluginPart(
+                source_path="engine-plugin-azure", source_name="shim"
+            ),
+            CMDBEnginePluginPart(source_path="engine-plugin-cmdb", source_name="shim"),
+            WrapperEnginePart(source_path="engine-wrapper", source_name="shim"),
+        ]
+
+        engine = ShimEngine(
+            name="shim",
+            description="The engine used to provide shim based access to a fixed diretory",
+        )
+        engine.parts = engine_parts
+        engine.sources = engine_source
+
+        yield engine
+
+
+class BundledShimEngineLoader(EngineLoader):
+    """
+    Seeds an engine used to create a known engine directory that can be used to establish
+    a standard location for hamlet scripts called outside of the cli
+    """
+
+    def load(self) -> typing.Iterable[Engine]:
+        engine_source = [
+            ShimPathEngineSource(name="shim", description="shim based root dir source")
+        ]
+
+        engine_parts = [
+            CoreEnginePart(source_path="engine-core", source_name="shim"),
+            BashExecutorEnginePart(source_path="executor-bash", source_name="shim"),
+            AWSEnginePluginPart(source_path="engine-plugin-aws", source_name="shim"),
+            AzureEnginePluginPart(
+                source_path="engine-plugin-azure", source_name="shim"
+            ),
+            CMDBEnginePluginPart(source_path="engine-plugin-cmdb", source_name="shim"),
+            BundledWrapperEnginePart(source_path="engine-wrapper", source_name="shim"),
+        ]
+
+        engine = ShimEngine(
+            name="bundled_shim",
+            description="The engine used to provide shim based access to a fixed diretory",
+        )
+        engine.parts = engine_parts
+        engine.sources = engine_source
+
+        yield engine

--- a/hamlet/backend/engine/loaders/shim.py
+++ b/hamlet/backend/engine/loaders/shim.py
@@ -10,7 +10,7 @@ from hamlet.backend.engine.engine_part import (
     CMDBEnginePluginPart,
     BashExecutorEnginePart,
     WrapperEnginePart,
-    BundledWrapperEnginePart
+    BundledWrapperEnginePart,
 )
 from hamlet.backend.engine.engine_source import ShimPathEngineSource
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- adds a new shim engine that will be used when working with bundled installations of the engine core

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for supporting the legacy direct bash calling method with the newer bundled cli 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

