### PR TITLE
feat: add support for bundled engine train releases

### DIFF
--- a/hamlet/backend/engine/loaders/train.py
+++ b/hamlet/backend/engine/loaders/train.py
@@ -10,7 +10,7 @@ from hamlet.backend.engine.engine_part import (
     AzureEnginePluginPart,
     BashExecutorEnginePart,
     WrapperEnginePart,
-    BundledWrapperEnginePart
+    BundledWrapperEnginePart,
 )
 from hamlet.backend.engine.engine_source import ContainerEngineSource
 from hamlet.backend.container_registry import ContainerRepository
@@ -111,7 +111,8 @@ class TrainEngineLoader(EngineLoader):
                 if version.match(">=8.5.0"):
                     engine_parts.append(
                         BundledWrapperEnginePart(
-                            source_path="engine-core/image/", source_name="hamlet-engine-base"
+                            source_path="engine-core/image/",
+                            source_name="hamlet-engine-base",
                         )
                     )
                 else:

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "simple-term-menu>=1.4.1,<2.0.0",
         # Diagrams
         "diagrams>=0.18.0,<1.0.0",
+        "semver>=2.13.0,<3.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for migrating between the bundled engine wrapper and the local engine wrapper depending on the version of engine being used

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Starting from hamlet 8.5.0 the bundled wrapper is the preferred way of working with hamlet. This adds support for that in the cli and automatically switches the engine part based on the version

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

