### PR TITLE
fix: add hamlet_home_dir back to base options

### DIFF
--- a/hamlet/backend/contract/__init__.py
+++ b/hamlet/backend/contract/__init__.py
@@ -6,7 +6,7 @@ from hamlet.backend.contract.tasks.exceptions import (
 )
 
 
-def run(contract, silent, engine):
+def run(contract, silent, engine, env):
 
     properties = contract["Properties"]
 
@@ -41,7 +41,7 @@ def run(contract, silent, engine):
                                 properties.get(property, ""),
                             )
 
-            replaced_params["env"] = engine.environment
+            replaced_params["env"] = {**engine.environment, **env}
             try:
                 task_result = task.run(**replaced_params)
 

--- a/hamlet/command/common/config.py
+++ b/hamlet/command/common/config.py
@@ -129,6 +129,16 @@ class Options:
         self._set_option("cli_config_dir", value)
 
     @property
+    def hamlet_home_dir(self):
+        """The home dir used by hamlet"""
+        return self._get_option("hamlet_home_dir")
+
+    @hamlet_home_dir.setter
+    def hamlet_home_dir(self, value):
+        """set the hamlet home dir"""
+        self._set_option("hamlet_home_dir", value)
+
+    @property
     def cli_cache_dir(self):
         """The cli cache dir"""
         return self._get_option("cli_cache_dir")

--- a/hamlet/command/common/decorators.py
+++ b/hamlet/command/common/decorators.py
@@ -6,7 +6,7 @@ import functools
 from hamlet.command.common.config import Options
 
 
-def get_home_dir_default(subdir):
+def get_home_dir_default(subdir=""):
     return os.path.join(
         click.get_app_dir(app_name="hamlet", force_posix=True, roaming=False), subdir
     )
@@ -40,6 +40,15 @@ def common_cli_config_options(func):
         show_envvar=True,
     )
     @click.option(
+        "--hamlet-home-dir",
+        type=click.Path(file_okay=False, dir_okay=True, readable=True, writable=True),
+        envvar="HAMLET_HOME_DIR",
+        default=get_home_dir_default(),
+        help="The home directory used by hamlet",
+        show_default=True,
+        show_envvar=True,
+    )
+    @click.option(
         "--cli-cache-dir",
         type=click.Path(file_okay=False, dir_okay=True, readable=True, writable=True),
         envvar="HAMLET_CLI_CACHE_DIR",
@@ -56,6 +65,7 @@ def common_cli_config_options(func):
         """
         opts = ctx.ensure_object(Options)
         opts.cli_cache_dir = kwargs.pop("cli_cache_dir")
+        opts.hamlet_home_dir = kwargs.pop("hamlet_home_dir")
         opts.load_config_file(
             profile=kwargs.pop("profile"), searchpath=kwargs.pop("cli_config_dir")
         )

--- a/hamlet/command/task/__init__.py
+++ b/hamlet/command/task/__init__.py
@@ -167,4 +167,9 @@ def run_runbook(options, name, confirm, silent, inputs, **kwargs):
         contract = query_backend.run(
             **query_args, engine=options.engine, cwd=os.getcwd(), query=None
         )
-        contract_backend.run(contract, silent, options.engine)
+        contract_backend.run(
+            contract,
+            silent,
+            options.engine,
+            {"HAMLET_HOME_DIR": options.opts.get("hamlet_home_dir", "")},
+        )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- reinstates the hamlet_home_dir option that is used for a shared location for persistent data between command calls.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This was removed in  a recent change and the impact wasn't found until a bash script was run which required the env var to be set. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

