### PR TITLE
feat: aws s3 copy rm tasks

### DIFF
--- a/hamlet/backend/contract/tasks/aws_s3_download_bucket/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_s3_download_bucket/__init__.py
@@ -1,0 +1,46 @@
+import boto3
+import os
+
+
+def run(
+    BucketName,
+    Prefix,
+    LocalPath,
+    Region=None,
+    AWSAccessKeyId=None,
+    AWSSecretAccessKey=None,
+    AWSSessionToken=None,
+    env={},
+):
+    """
+    Download the objects matching a prefix to a local directory from an S3 Bucket
+    """
+
+    session = boto3.Session(
+        aws_access_key_id=AWSAccessKeyId,
+        aws_secret_access_key=AWSSecretAccessKey,
+        aws_session_token=AWSSessionToken,
+        region_name=Region,
+    )
+
+    s3 = session.resource("s3")
+    bucket = s3.Bucket(BucketName)
+    object_count = 0
+
+    for object in bucket.objects.filter(Prefix=Prefix):
+        object_count += 1
+        local_path = os.path.join(
+            os.path.abspath(LocalPath),
+            object.key[len(os.path.commonpath([Prefix, object.key])):]
+        )
+
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        s3.Object(object.bucket_name, object.key).download_file(local_path)
+
+    return {
+        "Properties": {
+            "object_count": str(object_count),
+            "s3_path": f"s3://{BucketName}/" + Prefix,
+            "local_path": LocalPath
+        }
+    }

--- a/hamlet/backend/contract/tasks/aws_s3_download_bucket/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_s3_download_bucket/__init__.py
@@ -31,7 +31,7 @@ def run(
         object_count += 1
         local_path = os.path.join(
             os.path.abspath(LocalPath),
-            object.key[len(os.path.commonpath([Prefix, object.key])):]
+            object.key[len(os.path.commonpath([Prefix, object.key])) :],
         )
 
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
@@ -41,6 +41,6 @@ def run(
         "Properties": {
             "object_count": str(object_count),
             "s3_path": f"s3://{BucketName}/" + Prefix,
-            "local_path": LocalPath
+            "local_path": LocalPath,
         }
     }

--- a/hamlet/backend/contract/tasks/aws_s3_empty_bucket/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_s3_empty_bucket/__init__.py
@@ -38,6 +38,6 @@ def run(
     return {
         "Properties": {
             "object_count": str(object_count),
-            "s3_path": f"s3://{BucketName}/" + Prefix
+            "s3_path": f"s3://{BucketName}/" + Prefix,
         }
     }

--- a/hamlet/backend/contract/tasks/aws_s3_empty_bucket/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_s3_empty_bucket/__init__.py
@@ -1,0 +1,43 @@
+import boto3
+
+
+def run(
+    BucketName,
+    Prefix,
+    Region=None,
+    AWSAccessKeyId=None,
+    AWSSecretAccessKey=None,
+    AWSSessionToken=None,
+    env={},
+):
+    """
+    Remove all objects from an S3 bucket prefix
+    """
+
+    session = boto3.Session(
+        aws_access_key_id=AWSAccessKeyId,
+        aws_secret_access_key=AWSSecretAccessKey,
+        aws_session_token=AWSSessionToken,
+        region_name=Region,
+    )
+
+    s3 = session.resource("s3")
+    bucket = s3.Bucket(BucketName)
+    object_count = 0
+
+    if bucket.Versioning().status in ["Enabled", "Suspended"]:
+        for object in bucket.object_versions.filter(Prefix=Prefix):
+            object_count += 1
+            object.delete()
+
+    else:
+        for object in bucket.objects.filter(Prefix=Prefix):
+            object_count += 1
+            object.delete()
+
+    return {
+        "Properties": {
+            "object_count": str(object_count),
+            "s3_path": f"s3://{BucketName}/" + Prefix
+        }
+    }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

- adds tasks for aws s3 related actions
  - emptying a bucket included versions
  - Copying the contents of a bucket locally

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->

Allows for managing objects stored in s3 buckets

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

