### PR TITLE
feat: add contract task for SES SMTP password generation

### DIFF
--- a/hamlet/backend/contract/__init__.py
+++ b/hamlet/backend/contract/__init__.py
@@ -36,10 +36,15 @@ def run(contract, silent, engine, env):
                     for substitution in substitutions:
                         if substitution.startswith("Properties:"):
                             property = substitution.split(":", 1)[1]
-                            replaced_params[k] = replaced_params[k].replace(
-                                f"__Properties:{property}__",
-                                properties.get(property, ""),
-                            )
+
+                            replacement_value = properties.get(property, "")
+                            if isinstance(replacement_value, bool):
+                                replaced_params[k] = replacement_value
+                            else:
+                                replaced_params[k] = replaced_params[k].replace(
+                                    f"__Properties:{property}__",
+                                    str(properties.get(property, "")),
+                                )
 
             replaced_params["env"] = {**engine.environment, **env}
             try:

--- a/hamlet/backend/contract/tasks/aws_kms_decrypt_ciphertext/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_kms_decrypt_ciphertext/__init__.py
@@ -16,7 +16,7 @@ def run(
     the provided credentials and return the plaintext result as a string
     """
 
-    if EncryptionScheme != "":
+    if EncryptionScheme:
         Ciphertext = Ciphertext.replace(EncryptionScheme, "", 1)
     Ciphertext = b64decode(Ciphertext)
 

--- a/hamlet/backend/contract/tasks/aws_ses_smtp_password/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_ses_smtp_password/__init__.py
@@ -1,0 +1,39 @@
+import hmac
+import hashlib
+import base64
+
+
+# These values are required to calculate the signature. Do not change them.
+DATE = "11111111"
+SERVICE = "ses"
+MESSAGE = "SendRawEmail"
+TERMINAL = "aws4_request"
+VERSION = 0x04
+
+
+def run(
+    SESRegion,
+    AWSSecretAccessKey=None,
+    env={},
+):
+    """
+    Generate a Sig4 based SMTP password from a provided secret access key
+    Used with SES to send emails via SMTP
+    """
+
+    def sign(key, msg):
+        return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+    signature = sign(("AWS4" + AWSSecretAccessKey).encode("utf-8"), DATE)
+    signature = sign(signature, SESRegion)
+    signature = sign(signature, SERVICE)
+    signature = sign(signature, TERMINAL)
+    signature = sign(signature, MESSAGE)
+    signature_and_version = bytes([VERSION]) + signature
+    smtp_password = base64.b64encode(signature_and_version)
+
+    return {
+        "Properties": {
+            "smtp_password": smtp_password.decode("utf-8"),
+        }
+    }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a task to calculate an SMTP password from AWS access key
- Fixes comparison check of decryption
- Fixes support for boolean parameters on tasks.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Executor implementation of https://github.com/hamlet-io/engine-plugin-aws/pull/563

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

