### PR TITLE
refactor: deprecate commands replaced by runbooks and native commands

### DIFF
--- a/hamlet/command/manage/credentials_crypto.py
+++ b/hamlet/command/manage/credentials_crypto.py
@@ -8,6 +8,7 @@ from hamlet.command.common import exceptions
     "credential-crypto",
     short_help="Manage crypto for credential storage",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option(
     "-e",

--- a/hamlet/command/manage/crypto.py
+++ b/hamlet/command/manage/crypto.py
@@ -8,6 +8,7 @@ from hamlet.command.common import exceptions
     "crypto",
     short_help="Manage cryptographic operations using KMS",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option("-a", "--alias", help="alias for the master key to be used")
 @click.option(

--- a/hamlet/command/manage/deployment.py
+++ b/hamlet/command/manage/deployment.py
@@ -8,6 +8,7 @@ from hamlet.command.common import exceptions
     "deployment",
     short_help="Manage an Azure Resource Manager (ARM) deployment",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option("-d", "--delete", help="delete the deployment", is_flag=True)
 @click.option(

--- a/hamlet/command/manage/file_crypto.py
+++ b/hamlet/command/manage/file_crypto.py
@@ -8,6 +8,7 @@ from hamlet.command.common import exceptions
     "file-crypto",
     short_help="Manage crypto for files",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option("-d", "--decrypt", is_flag=True, help="decrypt file")
 @click.option("-e", "--encrypt", is_flag=True, help="encrypt file")

--- a/hamlet/command/manage/stack.py
+++ b/hamlet/command/manage/stack.py
@@ -8,6 +8,7 @@ from hamlet.command.common import exceptions
     "stack",
     short_help="Manage a CloudFormation stack",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option("-d", "--delete", help="delete the stack", is_flag=True)
 @click.option(

--- a/hamlet/command/run/lambda_func.py
+++ b/hamlet/command/run/lambda_func.py
@@ -8,6 +8,7 @@ from hamlet.command.common.config import pass_options
     "lambda",
     short_help="Run an AWS Lambda Function",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option(
     "-f",

--- a/hamlet/command/run/pipeline.py
+++ b/hamlet/command/run/pipeline.py
@@ -8,6 +8,7 @@ from hamlet.command.common.config import pass_options
     "pipeline",
     short_help="Run an AWS Data pipeline",
     context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option(
     "-i",

--- a/hamlet/command/run/task.py
+++ b/hamlet/command/run/task.py
@@ -5,7 +5,10 @@ from hamlet.command.common.config import pass_options
 
 
 @click.command(
-    "task", short_help="Run an ECS task", context_settings=dict(max_content_width=240)
+    "task",
+    short_help="Run an ECS task",
+    context_settings=dict(max_content_width=240),
+    deprecated=True,
 )
 @click.option(
     "-t",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Add deprecation notices for commands which have moved into contract based execution processes

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The commands current map directly to bash scripts in the bash executor which are scheduled for removal in the next major release. This starts the process of getting them removed

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

