### PR TITLE
refactor: remove cache outputs

### DIFF
--- a/hamlet/backend/automation/properties_file/__init__.py
+++ b/hamlet/backend/automation/properties_file/__init__.py
@@ -12,7 +12,6 @@ def get_automation_properties(engine=None, **kwargs):
         "generation_entrance": "releaseinfo",
         "output_filename": "releaseinfo-config.json",
         "output_format": "default",
-        "use_cache": False,
     }
     automation_properties = query_backend.run(
         **query_args,

--- a/hamlet/backend/common/context.py
+++ b/hamlet/backend/common/context.py
@@ -1,6 +1,4 @@
 import os
-import json
-import hashlib
 from .exceptions import BackendException
 from .fsutils import ContextSearch, Search, File
 
@@ -83,11 +81,6 @@ class Context:
     def root_dir(self, value):
         self.__root_dir = value
 
-    # Cache dir path
-    @property
-    def cache_dir(self):
-        return self.__cache_dir
-
     @property
     def account_dir(self):
         return self._account_dir
@@ -108,16 +101,11 @@ class Context:
     def setup(self):
         pass
 
-    def md5_hash(self):
-        hash_str = f"{self.level_name}:{self.level_file}:{self.directory}:{json.dumps(self.config)}"
-        return hashlib.md5(hash_str.encode()).hexdigest()
-
     def __init__(
         self,
         directory: str,
         root_dir: str = None,
         config: dict = None,
-        cache_dir: str = None,
     ):
         config = config or {}
         self.config = config
@@ -133,11 +121,6 @@ class Context:
             self.__root_dir = root_dir
         else:
             self.__try_to_find_root()
-
-        if cache_dir is not None:
-            self.__cache_dir = cache_dir
-        else:
-            self.__cache_dir = os.path.join(self.__root_dir, "cache")
 
         if self.ACCOUNT_REQUIRED or self.TENANT_REQUIRED:
             self.__try_to_set_tenant()

--- a/hamlet/backend/deploy/__init__.py
+++ b/hamlet/backend/deploy/__init__.py
@@ -40,7 +40,6 @@ def find_deployments(
         "deployment_mode": deployment_mode,
         "generation_entrance": "unitlist",
         "output_filename": "unitlist-managementcontract.json",
-        "use_cache": False,
     }
     available_deployments = query_backend.run(
         **query_args,

--- a/hamlet/command/common/config.py
+++ b/hamlet/command/common/config.py
@@ -148,16 +148,6 @@ class Options:
         self._set_option("hamlet_home_dir", value)
 
     @property
-    def cli_cache_dir(self):
-        """The cli cache dir"""
-        return self._get_option("cli_cache_dir")
-
-    @cli_cache_dir.setter
-    def cli_cache_dir(self, value):
-        """Set the cli cache dir"""
-        self._set_option("cli_cache_dir", value)
-
-    @property
     def log_level(self):
         """Get the log_level setting"""
         return self._get_option("log_level")

--- a/hamlet/command/common/decorators.py
+++ b/hamlet/command/common/decorators.py
@@ -31,15 +31,6 @@ def common_cli_config_options(func):
         show_envvar=True,
     )
     @click.option(
-        "--cli-config-dir",
-        type=click.Path(file_okay=False, dir_okay=True, readable=True),
-        envvar="HAMLET_CLI_CONFIG_DIR",
-        default=get_home_dir_default("config"),
-        help="The directory where profile configuration is stored",
-        show_default=True,
-        show_envvar=True,
-    )
-    @click.option(
         "--hamlet-home-dir",
         type=click.Path(file_okay=False, dir_okay=True, readable=True, writable=True),
         envvar="HAMLET_HOME_DIR",
@@ -49,11 +40,11 @@ def common_cli_config_options(func):
         show_envvar=True,
     )
     @click.option(
-        "--cli-cache-dir",
-        type=click.Path(file_okay=False, dir_okay=True, readable=True, writable=True),
-        envvar="HAMLET_CLI_CACHE_DIR",
-        default=get_home_dir_default("cache"),
-        help="The directory where the cli can cache generation outputs",
+        "--cli-config-dir",
+        type=click.Path(file_okay=False, dir_okay=True, readable=True),
+        envvar="HAMLET_CLI_CONFIG_DIR",
+        default=get_home_dir_default("config"),
+        help="The directory where profile configuration is stored",
         show_default=True,
         show_envvar=True,
     )
@@ -64,7 +55,6 @@ def common_cli_config_options(func):
         Config file handling
         """
         opts = ctx.ensure_object(Options)
-        opts.cli_cache_dir = kwargs.pop("cli_cache_dir")
         opts.hamlet_home_dir = kwargs.pop("hamlet_home_dir")
         opts.load_config_file(
             profile=kwargs.pop("profile"), searchpath=kwargs.pop("cli_config_dir")

--- a/hamlet/command/component/common.py
+++ b/hamlet/command/component/common.py
@@ -19,7 +19,6 @@ def query_occurrences_state(
         **options.opts,
         "generation_entrance": "occurrences",
         "output_filename": "occurrences-state.json",
-        "use_cache": False,
     }
     query_result = query_backend.run(
         **query_args,

--- a/hamlet/command/component/component_types.py
+++ b/hamlet/command/component/component_types.py
@@ -14,7 +14,6 @@ def query_info_output(options, engine, query, query_params=None, sub_query_text=
         **options.opts,
         "generation_entrance": "info",
         "output_filename": "info.json",
-        "use_cache": False,
     }
     query_result = query_backend.run(
         **query_args,

--- a/hamlet/command/entrance/__init__.py
+++ b/hamlet/command/entrance/__init__.py
@@ -56,7 +56,6 @@ def list_entrances(options):
         "generation_input_source": "mock",
         "generation_entrance": "info",
         "output_filename": "info.json",
-        "use_cache": False,
     }
 
     return query_backend.run(

--- a/hamlet/command/layer/__init__.py
+++ b/hamlet/command/layer/__init__.py
@@ -16,7 +16,6 @@ def query_info_output(options, query, query_params=None, sub_query_text=None):
         **options.opts,
         "generation_entrance": "info",
         "output_filename": "info.json",
-        "use_cache": False,
     }
     query_result = query_backend.run(
         **query_args,

--- a/hamlet/command/reference/__init__.py
+++ b/hamlet/command/reference/__init__.py
@@ -16,7 +16,6 @@ def query_info_output(options, query, query_params=None, sub_query_text=None):
         **options.opts,
         "generation_entrance": "info",
         "output_filename": "info.json",
-        "use_cache": False,
     }
     query_result = query_backend.run(
         **query_args,

--- a/hamlet/command/release/__init__.py
+++ b/hamlet/command/release/__init__.py
@@ -19,7 +19,6 @@ def query_imagedetails_output(options, query, query_params=None, sub_query_text=
         **options.opts,
         "generation_entrance": "imagedetails",
         "output_filename": "imagedetails-config.json",
-        "use_cache": False,
     }
     query_result = query_backend.run(
         **query_args,

--- a/hamlet/command/schema/__init__.py
+++ b/hamlet/command/schema/__init__.py
@@ -18,7 +18,6 @@ def find_schemas_from_options(options, schema):
         "deployment_mode": None,
         "generation_entrance": "schemalist",
         "output_filename": "schemalist-schemacontract.json",
-        "use_cache": False,
     }
     available_schemas = query_backend.run(
         **query_args,

--- a/hamlet/command/task/__init__.py
+++ b/hamlet/command/task/__init__.py
@@ -18,7 +18,6 @@ def query_runbookinfo_state(options, query, query_params=None, sub_query_text=No
         **options.opts,
         "generation_entrance": "runbookinfo",
         "output_filename": "runbookinfo-config.json",
-        "use_cache": False,
     }
     query_result = query_backend.run(
         **query_args,
@@ -162,7 +161,6 @@ def run_runbook(options, name, confirm, silent, inputs, **kwargs):
                 f"RunBookInputs={json.dumps(inputs)}",
             ),
             "output_filename": "runbook-contract.json",
-            "use_cache": False,
         }
         contract = query_backend.run(
             **query_args, engine=options.engine, cwd=os.getcwd(), query=None

--- a/hamlet/command/visual/__init__.py
+++ b/hamlet/command/visual/__init__.py
@@ -24,7 +24,6 @@ def find_diagrams_from_options(options, ids):
         **options.opts,
         "generation_entrance": "diagraminfo",
         "output_filename": "diagraminfo.json",
-        "use_cache": False,
     }
     available_diagrams = query_backend.run(
         **query_args,
@@ -203,7 +202,6 @@ def list_diagram_types(options):
         "generation_input_source": "mock",
         "generation_entrance": "diagraminfo",
         "output_filename": "diagraminfo.json",
-        "use_cache": False,
     }
 
     return query_backend.run(

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,6 @@ norecursedirs = .git .tox requirements* .venv var
 python_files = test_*.py
 addopts = -p no:warnings
 testpaths = tests
+
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "click>=8.0.3,<9.0.0",
         "click-configfile>=0.2.3,<1.0.0",
-        "cookiecutter>=1.7.0,<2.0.0",
+        "cookiecutter>=2.1.1,<3.0.0",
         "tabulate>=0.8.0,<1.0.0",
         "Jinja2>=3.0.3,<4.0.0",
         "jmespath>=0.10.0,<1.0.0",

--- a/tests/system/cmdb/product/test_scenario.py
+++ b/tests/system/cmdb/product/test_scenario.py
@@ -1,8 +1,10 @@
+import pytest
 from . import step_1_create_cmdb
 from . import step_2_create_account_templates
 from . import step_3_create_segment_templates
 
 
+@pytest.mark.slow
 def test_tenant_and_product_setup(engine, cmdb, clear_cmdb):
     step_1_create_cmdb.run(cmdb, clear_cmdb)
     step_2_create_account_templates.run(cmdb, engine)

--- a/tests/unit/command/component/test_component_types.py
+++ b/tests/unit/command/component/test_component_types.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -31,48 +29,21 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
-        os.makedirs(output_dir, exist_ok=True)
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         filename = os.path.join(output_dir, output_filename)
-        with open(filename, "wt+") as f:
-            json.dump(data, f)
+        if data:
+            with open(filename, "wt+") as f:
+                json.dump(data, f)
 
     return run
 
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -85,10 +56,7 @@ DECSCRIBE_TYPE_VALID_OPTIONS["-q,--query"] = "[]"
 
 
 @mock_backend(info_mock_output)
-def test_describe_component_type_input_valid(
-    blueprint_mock,
-    ContextClassMock,
-):
+def test_describe_component_type_input_valid(blueprint_mock):
     run_options_test(
         CliRunner(),
         describe_component_type,
@@ -98,7 +66,7 @@ def test_describe_component_type_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_describe_component_type(blueprint_mock, ContextClassMock):
+def test_describe_component_type(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/component/test_occurrence.py
+++ b/tests/unit/command/component/test_occurrence.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 from unittest import mock
 from click.testing import CliRunner
 
@@ -13,49 +11,21 @@ from hamlet.command.component.common import DescribeContext
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="occurrences",
-        entrance_parameter=None,
-        output_filename="occurrences-state.json",
-        output_dir=None,
-        deployment_mode=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        district_type=None,
-        root_dir=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
-        os.makedirs(output_dir, exist_ok=True)
-        blueprint_filename = os.path.join(output_dir, output_filename)
-        with open(blueprint_filename, "wt+") as f:
+    def run(output_filename="occurrences-state.json", output_dir=None, *args, **kwargs):
+        filename = os.path.join(output_dir, output_filename)
+        with open(filename, "wt+") as f:
             json.dump(data, f)
 
     return run
 
 
-def mock_backend(blueprint=None):
+def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
+        def wrapper(blueprint_mock, *args, **kwargs):
 
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(blueprint).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-
-                blueprint_mock.run.side_effect = template_backend_run_mock(blueprint)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -116,10 +86,10 @@ occurrence_state_data = {
 
 
 @mock_backend(occurrence_state_data)
-def test_list_occurrences(blueprint_mock, ContextClassMock):
+def test_list_occurrences(blueprint_mock):
     cli = CliRunner()
     result = cli.invoke(list_occurrences, ["--output-format", "json"])
-    print(result.exception)
+    print(result.stdout)
     assert result.exit_code == 0
     result = json.loads(result.output)
     print(result)
@@ -140,7 +110,7 @@ def test_list_occurrences(blueprint_mock, ContextClassMock):
 
 @mock_describe_context("CoreRawName[1]")
 @mock_backend(occurrence_state_data)
-def test_describe_occurrence(blueprint_mock, ContextClassMock):
+def test_describe_occurrence(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(describe_occurrence, ["--name", "CoreRawName[1]"])
@@ -151,7 +121,7 @@ def test_describe_occurrence(blueprint_mock, ContextClassMock):
 
 @mock_describe_context("CoreRawName[1]")
 @mock_backend(occurrence_state_data)
-def test_describe_occurrence_query(blueprint_mock, ContextClassMock):
+def test_describe_occurrence_query(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(
@@ -165,7 +135,7 @@ def test_describe_occurrence_query(blueprint_mock, ContextClassMock):
 
 @mock_describe_context("CoreRawName[1]")
 @mock_backend(occurrence_state_data)
-def test_describe_occurrence_query_solution(blueprint_mock, ContextClassMock):
+def test_describe_occurrence_query_solution(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(describe_occurrence, ["--name", "CoreRawName[1]", "solution"])
@@ -176,7 +146,7 @@ def test_describe_occurrence_query_solution(blueprint_mock, ContextClassMock):
 
 @mock_describe_context("CoreRawName[1]")
 @mock_backend(occurrence_state_data)
-def test_describe_occurrence_query_resources(blueprint_mock, ContextClassMock):
+def test_describe_occurrence_query_resources(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(describe_occurrence, ["--name", "CoreRawName[1]", "resources"])
@@ -189,7 +159,7 @@ def test_describe_occurrence_query_resources(blueprint_mock, ContextClassMock):
 
 @mock_describe_context("CoreRawName[1]")
 @mock_backend(occurrence_state_data)
-def test_describe_occurrence_query_setting_namespaces(blueprint_mock, ContextClassMock):
+def test_describe_occurrence_query_setting_namespaces(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(
@@ -202,7 +172,7 @@ def test_describe_occurrence_query_setting_namespaces(blueprint_mock, ContextCla
 
 @mock_describe_context("CoreRawName[1]")
 @mock_backend(occurrence_state_data)
-def test_describe_occurrence_query_attributes(blueprint_mock, ContextClassMock):
+def test_describe_occurrence_query_attributes(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(
@@ -221,7 +191,7 @@ def test_describe_occurrence_query_attributes(blueprint_mock, ContextClassMock):
 
 
 @mock_backend(occurrence_state_data)
-def test_query_occurrences(blueprint_mock, ContextClassMock):
+def test_query_occurrences(blueprint_mock):
 
     cli = CliRunner()
     result = cli.invoke(

--- a/tests/unit/command/deploy/test_deploy.py
+++ b/tests/unit/command/deploy/test_deploy.py
@@ -1,6 +1,4 @@
 import collections
-import tempfile
-import hashlib
 import json
 import os
 
@@ -25,27 +23,14 @@ ALL_VALID_OPTIONS["--dryrun"] = True
 
 def template_backend_run_mock(data):
     def run(
-        entrance="unitlist",
-        entrance_parameter=None,
         output_filename="unitlist-managementcontract.json",
-        deployment_mode=None,
         output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
+        *args,
+        **kwargs
     ):
         os.makedirs(output_dir, exist_ok=True)
-        unitlist_filename = os.path.join(output_dir, output_filename)
-        with open(unitlist_filename, "wt+") as f:
+        filepath = os.path.join(output_dir, output_filename)
+        with open(filepath, "wt+") as f:
             json.dump(data, f)
 
     return run
@@ -55,34 +40,23 @@ def mock_backend(unitlist=None):
     def decorator(func):
         @mock.patch("hamlet.command.deploy.run.run_deployment")
         @mock.patch("hamlet.command.deploy.run.create_deployment")
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
         def wrapper(
             blueprint_mock,
-            ContextClassMock,
             create_deployment_backend,
             run_deployment_backend,
             *args,
             **kwargs
         ):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
+            blueprint_mock.run.side_effect = template_backend_run_mock(unitlist)
 
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(unitlist).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-
-                blueprint_mock.run.side_effect = template_backend_run_mock(unitlist)
-
-                return func(
-                    blueprint_mock,
-                    ContextClassMock,
-                    create_deployment_backend,
-                    run_deployment_backend,
-                    *args,
-                    **kwargs
-                )
+            return func(
+                blueprint_mock,
+                create_deployment_backend,
+                run_deployment_backend,
+                *args,
+                **kwargs
+            )
 
         return wrapper
 
@@ -121,9 +95,7 @@ unit_list = {
 
 
 @mock_backend(unit_list)
-def test_input_valid(
-    blueprint_mock, ContextClassMock, create_deployment_backend, run_deployment_backend
-):
+def test_input_valid(blueprint_mock, create_deployment_backend, run_deployment_backend):
     run_options_test(
         CliRunner(), run_deployments, ALL_VALID_OPTIONS, blueprint_mock.run
     )
@@ -131,7 +103,7 @@ def test_input_valid(
 
 @mock_backend(unit_list)
 def test_input_validation(
-    blueprint_mock, ContextClassMock, create_deployment_backend, run_deployment_backend
+    blueprint_mock, create_deployment_backend, run_deployment_backend
 ):
     runner = CliRunner()
     run_validatable_option_test(

--- a/tests/unit/command/entrance/test_list.py
+++ b/tests/unit/command/entrance/test_list.py
@@ -1,32 +1,12 @@
 import os
-import hashlib
 import json
-import tempfile
 from unittest import mock
 from click.testing import CliRunner
 from hamlet.command.entrance import list_entrances as list_entrances
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        deployment_mode=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         info_filename = os.path.join(output_dir, output_filename)
         with open(info_filename, "wt+") as f:
@@ -37,20 +17,11 @@ def template_backend_run_mock(data):
 
 def mock_backend(info=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(info)
 
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(info).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-
-                blueprint_mock.run.side_effect = template_backend_run_mock(info)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -65,7 +36,7 @@ def mock_backend(info=None):
         ]
     }
 )
-def test_query_list_entrances(blueprint_mock, ContextClassMock):
+def test_query_list_entrances(blueprint_mock):
     cli = CliRunner()
     result = cli.invoke(list_entrances, ["--output-format", "json"])
     print(result.exception)

--- a/tests/unit/command/layer/test_describe.py
+++ b/tests/unit/command/layer/test_describe.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -47,25 +45,7 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
         with open(filename, "wt+") as f:
@@ -76,19 +56,11 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
 
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -103,7 +75,6 @@ DECSCRIBE_TYPE_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_describe_layer_type_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -114,7 +85,9 @@ def test_describe_layer_type_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_describe_layer_type(blueprint_mock, ContextClassMock):
+def test_describe_layer_type(
+    blueprint_mock,
+):
     obj = Options()
 
     cli = CliRunner()
@@ -139,7 +112,6 @@ DECSCRIBE_LAYER_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_describe_layer_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -150,7 +122,7 @@ def test_describe_layer_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_describe_layer(blueprint_mock, ContextClassMock):
+def test_describe_layer(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/layer/test_list.py
+++ b/tests/unit/command/layer/test_list.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -47,25 +45,7 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
         with open(filename, "wt+") as f:
@@ -76,19 +56,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -103,7 +74,6 @@ LIST_TYPES_VALID_OPTIONS["--output-format"] = "json"
 @mock_backend(info_mock_output)
 def test_list_layer_types_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(), list_layer_types, LIST_TYPES_VALID_OPTIONS, blueprint_mock.run
@@ -111,7 +81,9 @@ def test_list_layer_types_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_list_layer_types(blueprint_mock, ContextClassMock):
+def test_list_layer_types(
+    blueprint_mock,
+):
     obj = Options()
 
     cli = CliRunner()
@@ -140,7 +112,6 @@ LIST_LAYERS_VALID_OPTIONS["--output-format"] = "json"
 @mock_backend(info_mock_output)
 def test_list_layers_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(), list_layers, LIST_LAYERS_VALID_OPTIONS, blueprint_mock.run
@@ -148,7 +119,7 @@ def test_list_layers_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_list_layers(blueprint_mock, ContextClassMock):
+def test_list_layers(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/layer/test_query.py
+++ b/tests/unit/command/layer/test_query.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -46,25 +44,7 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
         with open(filename, "wt+") as f:
@@ -75,19 +55,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -101,7 +72,6 @@ QUERY_TYPES_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_query_layer_types_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -112,7 +82,7 @@ def test_query_layer_types_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_query_layer_types(blueprint_mock, ContextClassMock):
+def test_query_layer_types(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()
@@ -138,7 +108,6 @@ QUERY_LAYERS_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_query_layers_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -149,7 +118,7 @@ def test_query_layers_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_query_layers(blueprint_mock, ContextClassMock):
+def test_query_layers(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/reference/test_describe.py
+++ b/tests/unit/command/reference/test_describe.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -45,25 +43,7 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
         with open(filename, "wt+") as f:
@@ -74,19 +54,11 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
 
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -101,7 +73,6 @@ DECSCRIBE_TYPE_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_describe_reference_type_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -112,7 +83,7 @@ def test_describe_reference_type_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_describe_reference_type(blueprint_mock, ContextClassMock):
+def test_describe_reference_type(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()
@@ -139,7 +110,6 @@ DECSCRIBE_REFERENCE_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_describe_reference_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -150,7 +120,7 @@ def test_describe_reference_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_describe_reference(blueprint_mock, ContextClassMock):
+def test_describe_reference(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/reference/test_list.py
+++ b/tests/unit/command/reference/test_list.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -45,25 +43,7 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
         with open(filename, "wt+") as f:
@@ -74,19 +54,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -99,17 +70,14 @@ LIST_TYPES_VALID_OPTIONS["--output-format"] = "json"
 
 
 @mock_backend(info_mock_output)
-def test_list_reference_types_input_valid(
-    blueprint_mock,
-    ContextClassMock,
-):
+def test_list_reference_types_input_valid(blueprint_mock):
     run_options_test(
         CliRunner(), list_reference_types, LIST_TYPES_VALID_OPTIONS, blueprint_mock.run
     )
 
 
 @mock_backend(info_mock_output)
-def test_list_reference_types(blueprint_mock, ContextClassMock):
+def test_list_reference_types(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()
@@ -138,7 +106,6 @@ LIST_REFERENCES_VALID_OPTIONS["--output-format"] = "json"
 @mock_backend(info_mock_output)
 def test_list_references_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(), list_references, LIST_REFERENCES_VALID_OPTIONS, blueprint_mock.run
@@ -146,7 +113,7 @@ def test_list_references_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_list_references(blueprint_mock, ContextClassMock):
+def test_list_references(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/reference/test_query.py
+++ b/tests/unit/command/reference/test_query.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -44,25 +42,7 @@ info_mock_output = {
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="info",
-        entrance_parameter=None,
-        output_filename="info.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="info.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
         with open(filename, "wt+") as f:
@@ -73,19 +53,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -99,7 +70,6 @@ QUERY_TYPES_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_query_reference_types_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -110,7 +80,7 @@ def test_query_reference_types_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_query_reference_types(blueprint_mock, ContextClassMock):
+def test_query_reference_types(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()
@@ -136,7 +106,6 @@ QUERY_REFERENCES_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(info_mock_output)
 def test_query_references_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -147,7 +116,7 @@ def test_query_references_input_valid(
 
 
 @mock_backend(info_mock_output)
-def test_query_references(blueprint_mock, ContextClassMock):
+def test_query_references(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/schema/test_list.py
+++ b/tests/unit/command/schema/test_list.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 
 from unittest import mock
 from click.testing import CliRunner
@@ -11,23 +9,10 @@ from hamlet.command.common.config import Options
 
 def template_backend_run_mock(data):
     def run(
-        entrance="schemalist",
-        entrance_parameter=None,
         output_filename="schemalist-schemacontract.json",
-        deployment_mode=None,
         output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
+        *args,
+        **kwargs
     ):
         os.makedirs(output_dir, exist_ok=True)
         unitlist_filename = os.path.join(output_dir, output_filename)
@@ -39,20 +24,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(schemalist=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(schemalist).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-
-                blueprint_mock.run.side_effect = template_backend_run_mock(schemalist)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(schemalist)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -91,7 +66,7 @@ def mock_backend(schemalist=None):
         ]
     }
 )
-def test_query_list_schemas(blueprint_mock, ContextClassMock):
+def test_query_list_schemas(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/task/test_describe.py
+++ b/tests/unit/command/task/test_describe.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -32,23 +30,7 @@ runbookinfo_mock_output = {
 
 def template_backend_run_mock(data):
     def run(
-        entrance="runbookinfo",
-        entrance_parameter=None,
-        output_filename="runbookinfo-config.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
+        output_filename="runbookinfo-config.json", output_dir=None, *args, **kwargs
     ):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
@@ -60,19 +42,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -87,7 +60,6 @@ DECSCRIBE_RUNBOOK_VALID_OPTIONS["-q,--query"] = "[]"
 @mock_backend(runbookinfo_mock_output)
 def test_describe_runbook_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(),
@@ -98,7 +70,7 @@ def test_describe_runbook_input_valid(
 
 
 @mock_backend(runbookinfo_mock_output)
-def test_describe_runbook(blueprint_mock, ContextClassMock):
+def test_describe_runbook(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/task/test_list.py
+++ b/tests/unit/command/task/test_list.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 import collections
 
 from unittest import mock
@@ -32,23 +30,7 @@ runbookinfo_mock_output = {
 
 def template_backend_run_mock(data):
     def run(
-        entrance="runbookinfo",
-        entrance_parameter=None,
-        output_filename="runbookinfo-config.json",
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
+        output_filename="runbookinfo-config.json", output_dir=None, *args, **kwargs
     ):
         os.makedirs(output_dir, exist_ok=True)
         filename = os.path.join(output_dir, output_filename)
@@ -60,19 +42,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(data=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(data).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-                blueprint_mock.run.side_effect = template_backend_run_mock(data)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(data)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -87,7 +60,6 @@ LIST_RUNBOOKS_VALID_OPTIONS["--output-format"] = "json"
 @mock_backend(runbookinfo_mock_output)
 def test_list_runbooks_input_valid(
     blueprint_mock,
-    ContextClassMock,
 ):
     run_options_test(
         CliRunner(), list_runbooks, LIST_RUNBOOKS_VALID_OPTIONS, blueprint_mock.run
@@ -95,7 +67,7 @@ def test_list_runbooks_input_valid(
 
 
 @mock_backend(runbookinfo_mock_output)
-def test_list_runbooks(blueprint_mock, ContextClassMock):
+def test_list_runbooks(blueprint_mock):
     obj = Options()
 
     cli = CliRunner()

--- a/tests/unit/command/task/test_run.py
+++ b/tests/unit/command/task/test_run.py
@@ -1,6 +1,4 @@
 import collections
-import tempfile
-import hashlib
 import json
 import os
 
@@ -20,25 +18,7 @@ ALL_VALID_OPTIONS["--"] = "test=true"
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance=None,
-        entrance_parameter=None,
-        output_filename=None,
-        deployment_mode=None,
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename=None, output_dir=None, *args, **kwargs):
         for set in data:
             os.makedirs(output_dir, exist_ok=True)
             filename = os.path.join(output_dir, set[2])
@@ -51,29 +31,16 @@ def template_backend_run_mock(data):
 def mock_backend(runbookinfo=None, contract=None):
     def decorator(func):
         @mock.patch("hamlet.command.task.contract_backend")
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(
-            blueprint_mock, ContextClassMock, contract_backend, *args, **kwargs
-        ):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
+        def wrapper(blueprint_mock, contract_backend, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(
+                [
+                    (runbookinfo, "runbookinfo", "runbookinfo-config.json"),
+                    (contract, "runbook", "runbook-contract.json"),
+                ]
+            )
 
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(runbookinfo).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-
-                blueprint_mock.run.side_effect = template_backend_run_mock(
-                    [
-                        (runbookinfo, "runbookinfo", "runbookinfo-config.json"),
-                        (contract, "runbook", "runbook-contract.json"),
-                    ]
-                )
-
-                return func(
-                    blueprint_mock, ContextClassMock, contract_backend, *args, **kwargs
-                )
+            return func(blueprint_mock, contract_backend, *args, **kwargs)
 
         return wrapper
 
@@ -99,12 +66,12 @@ runbook_mock_output = {"Stages": [{"Id": "Stage1", "Steps": [{"Id": "Step1"}]}]}
 
 
 @mock_backend(runbookinfo_mock_output, runbook_mock_output)
-def test_input_valid(blueprint_mock, ContextClassMock, contract_backend):
+def test_input_valid(blueprint_mock, contract_backend):
     run_options_test(CliRunner(), run_runbook, ALL_VALID_OPTIONS, contract_backend.run)
 
 
 @mock_backend(runbookinfo_mock_output, runbook_mock_output)
-def test_input_validation(blueprint_mock, ContextClassMock, contract_backend):
+def test_input_validation(blueprint_mock, contract_backend):
     runner = CliRunner()
     run_validatable_option_test(
         runner,

--- a/tests/unit/command/test_option_generation.py
+++ b/tests/unit/command/test_option_generation.py
@@ -5,7 +5,7 @@ that we need to maintain. And because of that tests become much more accurate
 and reliable.
 
 Sure, manual individual testing is somewhat better but I think that we'll test "backend" part of our script separately.
-Therefore this module will be usefull even after we'll rewrite everything in python.
+Therefore this module will be useful even after we'll rewrite everything in python.
 """
 
 
@@ -130,7 +130,7 @@ def generate_test_options_collection(all_options):
             '--option', 'value',
             '--multi', 'b'
         ]
-    Function does not create all posible combinations. Instead it freezes first value of all keys with
+    Function does not create all possible combinations. Instead it freezes first value of all keys with
     iterable collection values and then creates variations by iterating over one of the keys with collection values
     untill all of them iterated.
     """
@@ -292,6 +292,7 @@ def run_options_test(runner, cmd, options, runner_mock):
     for args in generate_test_options_collection(options):
         result = runner.invoke(cmd, args)
         logger.info(result.exc_info)
+        print(result.stdout)
         assert result.exit_code == 0, result.output
         assert runner_mock.call_count == 1
         runner_mock.call_count = 0

--- a/tests/unit/command/visual/test_list.py
+++ b/tests/unit/command/visual/test_list.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import json
-import tempfile
 
 from unittest import mock
 
@@ -11,25 +9,7 @@ from hamlet.command.visual import list_diagram_types as list_diagram_types
 
 
 def template_backend_run_mock(data):
-    def run(
-        entrance="diagraminfo",
-        entrance_parameter=None,
-        output_filename="diagraminfo.json",
-        output_dir=None,
-        generation_input_source=None,
-        generation_provider=None,
-        generation_framework=None,
-        deployment_mode=None,
-        log_level=None,
-        root_dir=None,
-        district_type=None,
-        tenant=None,
-        account=None,
-        product=None,
-        environment=None,
-        segment=None,
-        engine=None,
-    ):
+    def run(output_filename="diagraminfo.json", output_dir=None, *args, **kwargs):
         os.makedirs(output_dir, exist_ok=True)
         info_filename = os.path.join(output_dir, output_filename)
         with open(info_filename, "wt+") as f:
@@ -40,20 +20,10 @@ def template_backend_run_mock(data):
 
 def mock_backend(info=None):
     def decorator(func):
-        @mock.patch("hamlet.backend.query.context.Context")
         @mock.patch("hamlet.backend.query.template")
-        def wrapper(blueprint_mock, ContextClassMock, *args, **kwargs):
-            with tempfile.TemporaryDirectory() as temp_cache_dir:
-
-                ContextObjectMock = ContextClassMock()
-                ContextObjectMock.md5_hash.return_value = str(
-                    hashlib.md5(str(info).encode()).hexdigest()
-                )
-                ContextObjectMock.cache_dir = temp_cache_dir
-
-                blueprint_mock.run.side_effect = template_backend_run_mock(info)
-
-                return func(blueprint_mock, ContextClassMock, *args, **kwargs)
+        def wrapper(blueprint_mock, *args, **kwargs):
+            blueprint_mock.run.side_effect = template_backend_run_mock(info)
+            return func(blueprint_mock, *args, **kwargs)
 
         return wrapper
 
@@ -76,7 +46,7 @@ def mock_backend(info=None):
         ]
     }
 )
-def test_query_list_diagrams(blueprint_mock, ContextClassMock):
+def test_query_list_diagrams(blueprint_mock):
     cli = CliRunner()
     result = cli.invoke(list_diagrams, ["--output-format", "json"])
     print(result.exception)
@@ -109,7 +79,7 @@ def test_query_list_diagrams(blueprint_mock, ContextClassMock):
         ]
     }
 )
-def test_query_list_diagram_types(blueprint_mock, ContextClassMock):
+def test_query_list_diagram_types(blueprint_mock):
     cli = CliRunner()
     result = cli.invoke(list_diagram_types, ["--output-format", "json"])
     print(result.exception)


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- since it is difficult to determine when to either hit or miss the cache the caching has now been replaced with a tempdir when using query commands
- Removes the cli option to set the cache dir as its no longer used (and wasn't actually being used in the code)
- remove support for the context based cache in mock outputs
- only pass required args to backend mock
- Update cookie cutter for CVE-2022-24065

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Removes extra complexity in handling output generation in the executor
Removes the need for controlling an additional output directory which really only stores temp content

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and using test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

