### PR TITLE
fix: remove use of transport from httpx client

### DIFF
--- a/hamlet/backend/common/http_client.py
+++ b/hamlet/backend/common/http_client.py
@@ -9,13 +9,15 @@ class HTTPClient(Client):
     def __init__(
         self,
         *args,
-        http1: bool = True,
-        http2: bool = True,
-        timeout: Timeout(timeout=5.0, read=120.0),
+        timeout=Timeout(timeout=5.0, read=120.0),
         follow_redirects: bool = True,
         trust_env: bool = True,
         **kwargs
     ):
         super().__init__(
-            *args, http1, http2, timeout, follow_redirects, trust_env, **kwargs
+            *args,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            trust_env=trust_env,
+            **kwargs
         )

--- a/hamlet/backend/common/http_client.py
+++ b/hamlet/backend/common/http_client.py
@@ -17,11 +17,5 @@ class HTTPClient(Client):
         **kwargs
     ):
         super().__init__(
-            *args,
-            http1,
-            http2,
-            timeout,
-            follow_redirects,
-            trust_env,
-            **kwargs
+            *args, http1, http2, timeout, follow_redirects, trust_env, **kwargs
         )

--- a/hamlet/backend/common/http_client.py
+++ b/hamlet/backend/common/http_client.py
@@ -1,0 +1,27 @@
+from httpx import Client, Timeout
+
+
+class HTTPClient(Client):
+    """
+    A standard httpx client used in the hamlet cli
+    """
+
+    def __init__(
+        self,
+        *args,
+        http1: bool = True,
+        http2: bool = True,
+        timeout: Timeout(timeout=5.0, read=120.0),
+        follow_redirects: bool = True,
+        trust_env: bool = True,
+        **kwargs
+    ):
+        super().__init__(
+            *args,
+            http1,
+            http2,
+            timeout,
+            follow_redirects,
+            trust_env,
+            **kwargs
+        )

--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -8,21 +8,15 @@ import typing
 import www_authenticate
 import json
 
+from common.http_client import HTTPClient
+
 from urllib import parse
 
-timeout = httpx.Timeout(timeout=5.0, read=120.0)
-transport = httpx.HTTPTransport(retries=3)
-
-container_httpx_client = httpx.Client(
-    headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
-    follow_redirects=True,
-    transport=transport,
-    timeout=timeout,
+container_httpx_client = HTTPClient(
+    headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
 )
 
-auth_httpx_client = httpx.Client(
-    transport=transport,
-)
+auth_httpx_client = HTTPClient()
 
 
 class ContainerRepositoryException(BaseException):

--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -8,7 +8,7 @@ import typing
 import www_authenticate
 import json
 
-from common.http_client import HTTPClient
+from hamlet.backend.common.http_client import HTTPClient
 
 from urllib import parse
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Removes the custom transport option used for the container image client as it also disables the use of env proxy configuration
- Creates a standard http client that should be used hamlet overall to ensure consistency in the use of the http client

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When running the hamlet cli in locked down environments where outbound DNS lookups are disabled using the transport client would disable any proxy settings and cause the connection to fail.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

