### PR TITLE
refactor: remove deprecated expo_app_publish param

### DIFF
--- a/hamlet/backend/run/expo_app_publish/__init__.py
+++ b/hamlet/backend/run/expo_app_publish/__init__.py
@@ -2,16 +2,10 @@ from hamlet.backend.common import runner
 
 
 def run(
+    deployment_group=None,
     deployment_unit=None,
-    run_setup=None,
-    force_binary_build=None,
-    submit_binary=None,
-    binary_build_process=None,
     build_logs=None,
-    environment_badge=None,
-    environment_badge_content=None,
     node_package_manager=None,
-    app_version_source=None,
     binary_output_dir=None,
     log_level=None,
     log_format=None,
@@ -26,17 +20,11 @@ def run(
     **kwargs
 ):
     options = {
-        "-b": binary_build_process,
-        "-d": environment_badge_content,
-        "-e": environment_badge,
-        "-f": force_binary_build,
         "-l": build_logs,
-        "-m": submit_binary,
         "-n": node_package_manager,
         "-o": binary_output_dir,
-        "-s": run_setup,
         "-u": deployment_unit,
-        "-v": app_version_source,
+        "-g": deployment_group,
     }
     env = {
         "GENERATION_LOG_LEVEL": log_level,

--- a/hamlet/command/run/expo_app_publish.py
+++ b/hamlet/command/run/expo_app_publish.py
@@ -10,6 +10,13 @@ from hamlet.command.common.config import pass_options
     context_settings=dict(max_content_width=240),
 )
 @click.option(
+    "-l",
+    "--deployment-group",
+    help="mobile app deployment group",
+    default="application",
+    envvar="DEPLOYMENT_GROUP",
+)
+@click.option(
     "-u",
     "--deployment-unit",
     required=True,
@@ -17,58 +24,10 @@ from hamlet.command.common.config import pass_options
     envvar="DEPLOYMENT_UNIT",
 )
 @click.option(
-    "-s",
-    "--run-setup",
-    is_flag=True,
-    help="run setup installation to prepare",
-    envvar="RUN_SETUP",
-)
-@click.option(
-    "-f",
-    "--force-binary-build",
-    help="force the build of binary images",
-    is_flag=True,
-    envvar="FORCE_BINARY_BUILD",
-)
-@click.option(
-    "-m",
-    "--submit-binary",
-    help="submit the binary for testing",
-    is_flag=True,
-    envvar="SUBMIT_BINARY",
-)
-@click.option(
-    "-b",
-    "--binary-build-process",
-    help="sets the build process to create the binary",
-    type=click.Choice(["fastlane", "turtle"]),
-    envvar="BINARY_BUILD_PROCESS",
-)
-@click.option(
-    "-l",
-    "--build-logs",
-    help="Show the full build logs",
-    is_flag=True,
-    envvar="BUILD_LOGS",
-)
-@click.option(
-    "-e",
-    "--environment-badge",
-    help="Add a badge to the app icons for the environment",
-    is_flag=True,
-    envvar="ENVIRONMENT_BADGE",
-)
-@click.option(
-    "-d",
-    "--environment-badge-content",
-    help="An override to the environment badge content",
-    envvar="ENVIRONMENT_BADGE_CONTENT",
-)
-@click.option(
     "-n",
     "--node-package-manager",
     help="The node package manager to use for builds",
-    type=click.Choice(["yarn", "npm"]),
+    type=click.Choice(["auto", "yarn", "npm"]),
     envvar="NODE_PACKAGE_MANAGER",
 )
 @click.option(
@@ -76,13 +35,6 @@ from hamlet.command.common.config import pass_options
     "--binary-output-dir",
     type=click.Path(dir_okay=True, file_okay=False, writable=True, resolve_path=True),
     help="The directory to save generated binaries to",
-)
-@click.option(
-    "-v",
-    "--app-version-source",
-    help="The method to use to source the app version",
-    type=click.Choice(["cmdb", "manifest"]),
-    envvar="APP_VERSION_SOURCE",
 )
 @exceptions.backend_handler()
 @pass_options
@@ -92,4 +44,9 @@ def expo_app_publish(options, **kwargs):
     """
 
     args = {**options.opts, **kwargs}
-    run_expo_app_publish_backend.run(**args, engine=options.engine, _is_cli=True)
+    run_expo_app_publish_backend.run(
+        **args,
+        build_logs=(options.opts.get("log_level", "info") in ["debug", "trace"]),
+        engine=options.engine,
+        _is_cli=True
+    )

--- a/tests/unit/command/run/test_expo_app_publish.py
+++ b/tests/unit/command/run/test_expo_app_publish.py
@@ -9,16 +9,9 @@ from tests.unit.command.test_option_generation import (
 
 
 ALL_VALID_OPTIONS = collections.OrderedDict()
+ALL_VALID_OPTIONS["-l,--deployment-group"] = "group"
 ALL_VALID_OPTIONS["!-u,--deployment-unit"] = "unit"
-ALL_VALID_OPTIONS["-s,--run-setup"] = [True, False]
-ALL_VALID_OPTIONS["-f,--force-binary-build"] = [True, False]
-ALL_VALID_OPTIONS["-m,--submit-binary"] = [True, False]
-ALL_VALID_OPTIONS["-b,--binary-build-process"] = "fastlane"
-ALL_VALID_OPTIONS["-l,--build-logs"] = [True, False]
-ALL_VALID_OPTIONS["-e,--environment-badge"] = [True, False]
-ALL_VALID_OPTIONS["-d,--environment-badge-content"] = "environment"
-ALL_VALID_OPTIONS["-n,--node-package-manager"] = "yarn"
-ALL_VALID_OPTIONS["-v,--app-version-source"] = "cmdb"
+ALL_VALID_OPTIONS["-n,--node-package-manager"] = "auto"
 ALL_VALID_OPTIONS["-o,--binary-output-dir"] = "binary_output_dir"
 
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Removes the parameters used in the expo_app_publish cli command which have now been removed from the underlying bash scripts

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Aligns with the changes made in https://github.com/hamlet-io/executor-bash/pull/348

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/executor-bash/pull/348

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

