### PR TITLE
feat: add dist option for sentry release

### DIFF
--- a/hamlet/backend/run/sentry_release/__init__.py
+++ b/hamlet/backend/run/sentry_release/__init__.py
@@ -8,6 +8,7 @@ def run(
     sentry_url_prefix=None,
     sentry_release_name=None,
     app_type=None,
+    dist=None,
     log_level=None,
     log_format=None,
     root_dir=None,
@@ -27,6 +28,7 @@ def run(
         "-u": deployment_unit,
         "-g": deployment_group,
         "-a": app_type,
+        "-d": dist,
     }
     env = {
         "GENERATION_LOG_LEVEL": log_level,

--- a/hamlet/command/run/sentry_release.py
+++ b/hamlet/command/run/sentry_release.py
@@ -33,7 +33,7 @@ from hamlet.command.common.config import pass_options
 @click.option(
     "-d",
     "--dist",
-    help="The distribution value",
+    help="A distribution Identifier for the file",
 )
 @click.option("-p", "--sentry-url-prefix", help="prefix for sourcemap files")
 @click.option(

--- a/hamlet/command/run/sentry_release.py
+++ b/hamlet/command/run/sentry_release.py
@@ -30,6 +30,11 @@ from hamlet.command.common.config import pass_options
     type=click.Choice(["", "react-native"]),
     help="The application framework being used",
 )
+@click.option(
+    "-d",
+    "--dist",
+    help="The distribution value",
+)
 @click.option("-p", "--sentry-url-prefix", help="prefix for sourcemap files")
 @click.option(
     "-r",

--- a/tests/unit/command/run/test_sentry_release.py
+++ b/tests/unit/command/run/test_sentry_release.py
@@ -11,6 +11,7 @@ ALL_VALID_OPTIONS["!-r,--sentry-release-name"] = "release_name"
 ALL_VALID_OPTIONS["-g,--deployment-group"] = "deployment_group"
 ALL_VALID_OPTIONS["-p,--sentry-url-prefix"] = "url_prefix"
 ALL_VALID_OPTIONS["-a,--app-type"] = "react-native"
+ALL_VALID_OPTIONS["-d,--dist"] = "distribution"
 
 
 @mock.patch("hamlet.command.run.sentry_release.run_sentry_release_backend")


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Adds -d option to support --dist argument for sentry releases command
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Sentry now requires distribution to be set along with the release during source maps upload for correct error processing.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

