### PR TITLE
fix: ecr docker login process

### DIFF
--- a/hamlet/backend/contract/tasks/aws_ecr_docker_login/__init__.py
+++ b/hamlet/backend/contract/tasks/aws_ecr_docker_login/__init__.py
@@ -55,10 +55,17 @@ def run(
     # directly using the docker command
     try:
         subprocess.run(
-            ["docker", "login", "--username", "AWS", "--password-stdin", auth_token["proxyEndpoint"]],
+            [
+                "docker",
+                "login",
+                "--username",
+                "AWS",
+                "--password-stdin",
+                auth_token["proxyEndpoint"],
+            ],
             input=ecr_password,
             check=True,
-            text=True
+            text=True,
         )
 
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- uses subprocess and the native docker client to login to ecr registries

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- The docker-py client doesn't save logins across sessions and stores the logins outside of the standard client login process
- This ensures that the login is provided to the docker client on the machine so that other runbook steps work as expected

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

