### PR TITLE
refactor: package management

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'master'
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   create_changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
       - name: install reqs
         run: |
-          pip install -e ./[dev]
+          pip install -e ./[dev] ./[output_testing] ./[diagrams]
 
       - name: Run tests
         run: |
@@ -37,10 +37,10 @@ jobs:
       - 'testing'
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -49,11 +49,11 @@ jobs:
           pip install -e ./[dev]
 
       - name: Create Release
-        run: >-
+        run: |
           python -m build --sdist --wheel --outdir dist/ .
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: install reqs
         run: |
-          pip install -e ./[dev] ./[output_testing] ./[diagrams]
+          pip install -e ./[dev]
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: install reqs
         run: |
-          pip install -e ./[dev]
+          pip install -e ./[dev] checkov cfn-lint diagrams
 
       - name: Run tests
         run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 

--- a/hamlet/backend/generate/utils.py
+++ b/hamlet/backend/generate/utils.py
@@ -1,14 +1,14 @@
 import os
 import shutil
 import tempfile
-import importlib_resources
 
+from importlib.resources import files, is_resource, path
 from cookiecutter.main import cookiecutter as cookiecutter_main
 from hamlet.backend.common.exceptions import BackendException
 
 
 def extract_package_to_temp(package, tmp_dir, root_dir, package_dir):
-    for entry in importlib_resources.files(package).joinpath(package_dir).iterdir():
+    for entry in files(package).joinpath(package_dir).iterdir():
         entry_path = os.path.commonprefix([root_dir, entry])
         entry_path = str(entry).replace(entry_path, "").lstrip("/")
 
@@ -32,12 +32,10 @@ def cookiecutter(template_package, output_dir, **kwargs):
 
     with tempfile.TemporaryDirectory() as template_dir:
 
-        if importlib_resources.is_resource(template_package, "cookiecutter.json"):
-            with importlib_resources.path(
-                template_package, "cookiecutter.json"
-            ) as path:
+        if is_resource(template_package, "cookiecutter.json"):
+            with path(template_package, "cookiecutter.json") as package_path:
                 extract_package_to_temp(
-                    template_package, template_dir, os.path.dirname(path), ""
+                    template_package, template_dir, os.path.dirname(package_path), ""
                 )
         else:
             raise BackendException(

--- a/hamlet/backend/test/templates/cfn_lint_test_func_block.py
+++ b/hamlet/backend/test/templates/cfn_lint_test_func_block.py
@@ -4,6 +4,12 @@
 def cfn_lint_test(filename, ignore_checks=None):
     import json
     import subprocess
+    import shutil
+
+    if shutil.which("cfn-lint") is None:
+        raise Exception(
+            "cfn-lint command not found install from https://github.com/aws-cloudformation/cfn-lint"
+        )
 
     cmd_args = ["cfn-lint", "-f", "json", filename]
 

--- a/hamlet/backend/test/templates/checkov_test_func_block.py
+++ b/hamlet/backend/test/templates/checkov_test_func_block.py
@@ -4,6 +4,12 @@
 def checkov_test(filename, framework, skip_checks=None):
     import json
     import subprocess
+    import shutil
+
+    if shutil.which("checkov") is None:
+        raise Exception(
+            "checkov command not found install from https://www.checkov.io/"
+        )
 
     cmd_args = [
         "checkov",

--- a/setup.py
+++ b/setup.py
@@ -35,23 +35,19 @@ setup(
         "tabulate>=0.8.0,<1.0.0",
         "Jinja2>=3.0.3,<4.0.0",
         "jmespath>=0.10.0,<1.0.0",
-        "importlib-resources>=5.2.0,<6.0.0",
         "www-authenticate>=0.9.2,<1.0.0",
         "httpx>=0.21.2,<1.0.0",
         "marshmallow>=3.7.0,<4.0.0",
+        "dulwich>=0.20.45,<1.0.0",
+        "semver>=2.13.0,<3.0.0",
         # contract execution
         "boto3>=1.20.0,<2.0.0",
         "botocore>=1.20.0,<2.0.0",
         "fabric>=2.6.0,<3.0.0",
         "simple-term-menu>=1.4.1,<2.0.0",
         "docker>=5.0.3,<6.0.0",
-        # Diagrams
-        "diagrams>=0.18.0,<1.0.0",
-        "semver>=2.13.0,<3.0.0",
         # Template testing
         "pytest>=6.0.0,<7.0.0",
-        "cfn-lint>=0.54.1,<1.0.0",
-        "checkov>=2.0.461,<3.0.0",
     ],
     extras_require={
         "dev": [
@@ -70,9 +66,16 @@ setup(
             "sphinx-markdown-builder",
             "sphinx-click",
         ],
+        "output_testing": [
+            "cfn-lint>=0.54.1,<1.0.0",
+            "checkov>=2.0.461,<3.0.0",
+        ],
+        "diagrams": [
+            "diagrams>=0.18.0,<1.0.0",
+        ],
     },
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={"console_scripts": ["hamlet=hamlet:command.root"]},
     classifiers=[
         "Natural Language :: English",

--- a/setup.py
+++ b/setup.py
@@ -65,15 +65,6 @@ setup(
             "Sphinx",
             "sphinx-markdown-builder",
             "sphinx-click",
-            "hamlet[output_testing]",
-            "hamlet[diagrams]",
-        ],
-        "output_testing": [
-            "cfn-lint>=0.72.2,<1.0.0",
-            "checkov>=2.2.130,<3.0.0",
-        ],
-        "diagrams": [
-            "diagrams>=0.18.0,<1.0.0",
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,12 @@ setup(
             "Sphinx",
             "sphinx-markdown-builder",
             "sphinx-click",
+            "hamlet[output_testing]",
+            "hamlet[diagrams]",
         ],
         "output_testing": [
-            "cfn-lint>=0.54.1,<1.0.0",
-            "checkov>=2.0.461,<3.0.0",
+            "cfn-lint>=0.72.2,<1.0.0",
+            "checkov>=2.2.130,<3.0.0",
         ],
         "diagrams": [
             "diagrams>=0.18.0,<1.0.0",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Remove the cfn-linkt, checkov and diagrams packages from base dependencies
- Make python3.7 the minimum supported version
- Remove the need to install importlib as its an included package in 3.7
- Remove changelog generation on pull requests
- Update gh action versions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This makes it easier to install hamlet as the package size should be considerably smaller. 
Checkov creates dependency issues as it adds the awscliv1 into python packages, with v2 no longer distribued as a pip package this causes downgrades from v2 -> v1 if python packages are first on a users path

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

