### PR TITLE
fix: zip checking for zip task

### DIFF
--- a/hamlet/backend/contract/tasks/file_zip_path/__init__.py
+++ b/hamlet/backend/contract/tasks/file_zip_path/__init__.py
@@ -13,7 +13,7 @@ def run(SourcePath, DestinationPath, env={}):
         create_zip = False
         try:
             source_zip = ZipFile(SourcePath, "r")
-            source_zip.getinfo()
+            source_zip.testzip()
         except (BadZipFile, LargeZipFile):
             create_zip = True
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
-  Fixes the healthcheck for the zip task to validate checksums on the zip instead of looking for a specific file

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Current task was failing as a filename was expected which can't be guaranteed inside the zip file at this stage

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

