### PR TITLE
fix: add importlib_resources for backwards compat

### DIFF
--- a/hamlet/backend/generate/utils.py
+++ b/hamlet/backend/generate/utils.py
@@ -2,9 +2,13 @@ import os
 import shutil
 import tempfile
 
-from importlib.resources import files, is_resource, path
 from cookiecutter.main import cookiecutter as cookiecutter_main
 from hamlet.backend.common.exceptions import BackendException
+
+try:
+    from importlib.resources import files, as_file
+except ModuleNotFoundError:
+    from importlib_resources import files, as_file
 
 
 def extract_package_to_temp(package, tmp_dir, root_dir, package_dir):
@@ -32,8 +36,8 @@ def cookiecutter(template_package, output_dir, **kwargs):
 
     with tempfile.TemporaryDirectory() as template_dir:
 
-        if is_resource(template_package, "cookiecutter.json"):
-            with path(template_package, "cookiecutter.json") as package_path:
+        if files(template_package).joinpath("cookiecutter.json").is_file():
+            with as_file(files(template_package).joinpath("cookiecutter.json")) as package_path:
                 extract_package_to_temp(
                     template_package, template_dir, os.path.dirname(package_path), ""
                 )

--- a/hamlet/backend/generate/utils.py
+++ b/hamlet/backend/generate/utils.py
@@ -37,7 +37,9 @@ def cookiecutter(template_package, output_dir, **kwargs):
     with tempfile.TemporaryDirectory() as template_dir:
 
         if files(template_package).joinpath("cookiecutter.json").is_file():
-            with as_file(files(template_package).joinpath("cookiecutter.json")) as package_path:
+            with as_file(
+                files(template_package).joinpath("cookiecutter.json")
+            ) as package_path:
                 extract_package_to_temp(
                     template_package, template_dir, os.path.dirname(package_path), ""
                 )

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "marshmallow>=3.7.0,<4.0.0",
         "dulwich>=0.20.45,<1.0.0",
         "semver>=2.13.0,<3.0.0",
+        "importlib_resources>=5.10.2,<6.0.0",
         # contract execution
         "boto3>=1.20.0,<2.0.0",
         "botocore>=1.20.0,<2.0.0",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Some native python3 installs (awslinux) are using 3.6 and lower of python. Using this backport ensures everything works on them

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Keep compatibility with old python versions

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

