### PR TITLE
feat: add support for OCI image indexes

### DIFF
--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -290,21 +290,15 @@ class ContainerRepository:
                                 )
                             )
 
-                        if (
-                            layer["mediaType"]
-                            in [
-                                "application/vnd.docker.image.rootfs.diff.tar.gzip",
-                                "application/vnd.oci.image.layer.v1.tar+gzip"
-                            ]
-                        ):
+                        if layer["mediaType"] in [
+                            "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                            "application/vnd.oci.image.layer.v1.tar+gzip",
+                        ]:
                             shutil.unpack_archive(layer_file.name, extract_dir, "gztar")
 
-                        elif (
-                            layer["mediaType"]
-                            in [
-                                "application/vnd.oci.image.layer.v1.tar"
-                            ]
-                        ):
+                        elif layer["mediaType"] in [
+                            "application/vnd.oci.image.layer.v1.tar"
+                        ]:
                             shutil.unpack_archive(layer_file.name, extract_dir, "tar")
 
                 if os.listdir(extract_dir):

--- a/hamlet/backend/container_registry/__init__.py
+++ b/hamlet/backend/container_registry/__init__.py
@@ -7,7 +7,6 @@ import httpx
 import typing
 import www_authenticate
 import json
-import click
 
 from hamlet.backend.common.http_client import HTTPClient
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- When using a Container Registry that supports OCI images the manifest returned can either be a single manifest or an index that contains a list of multi platform manifests
- Adds support for handling these manifests with initial preference for the linux based os as we don't use them to run images

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
With release https://github.com/docker/build-push-action/releases/tag/v3.3.0 of the docker build push action the version of BuildX was updated which now creates two manifest entries for every image. As a result new images were pushed up with an index manifest and the hamlet container registry client didn't understand that change. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite. 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

