### PR TITLE
fix: handle import failure for py36 compat

### DIFF
--- a/hamlet/backend/generate/utils.py
+++ b/hamlet/backend/generate/utils.py
@@ -7,7 +7,7 @@ from hamlet.backend.common.exceptions import BackendException
 
 try:
     from importlib.resources import files, as_file
-except ModuleNotFoundError:
+except (ImportError, ModuleNotFoundError):
     from importlib_resources import files, as_file
 
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Add an extra exception raised on python36 when the importlib resource module isn't available

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This ensures that hamlet works on older versions of python which are used in base OS images

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

