### PR TITLE
fix: path to the sh script for set_provider_credentails task

### DIFF
--- a/hamlet/backend/contract/tasks/set_provider_credentials/__init__.py
+++ b/hamlet/backend/contract/tasks/set_provider_credentials/__init__.py
@@ -23,7 +23,7 @@ def run(AccountId, ProviderId, Provider, env={}):
             "ACCOUNT_PROVIDER": Provider,
         }
         runner.run(
-            "/execution/setCredentials.sh",
+            "execution/setCredentials.sh",
             args=[],
             options={},
             env=env,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Fix the path for sh script which is executed set_provider_credentails task
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The current hamlet cli version is failing.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

