### PR TITLE
fix: pin urllib to version 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -49,6 +48,8 @@ setup(
         "docker>=5.0.3,<6.0.0",
         # Template testing
         "pytest>=6.0.0,<7.0.0",
+        # pin urllib for docker-py https://github.com/docker/docker-py/issues/3113
+        "urllib3<2",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Fixes an issue in docker-py where the urllib3 package isn't pinned and doesn't support version 3 of the package 
https://github.com/docker/docker-py/issues/3113

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Deployments failing if the older version was't picked up by depdencies

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

